### PR TITLE
[Fix] Network retrieval refactor

### DIFF
--- a/compiler/compiler/tests/compile.rs
+++ b/compiler/compiler/tests/compile.rs
@@ -141,7 +141,7 @@ fn run_test(test: Test, handler: &Handler, buf: &BufferEmitter) -> Result<Value,
 
             // Add the bytecode to the import stubs.
             let stub =
-                handler.extend_if_error(disassemble_from_str::<CurrentNetwork>(&bytecode).map_err(|err| err.into()))?;
+                handler.extend_if_error(disassemble_from_str::<CurrentNetwork>(&program_name, &bytecode).map_err(|err| err.into()))?;
             import_stubs.insert(Symbol::intern(&program_name), stub);
 
             // Hash the ast files.

--- a/compiler/compiler/tests/compile.rs
+++ b/compiler/compiler/tests/compile.rs
@@ -140,8 +140,9 @@ fn run_test(test: Test, handler: &Handler, buf: &BufferEmitter) -> Result<Value,
             handler.extend_if_error(process.add_program(&aleo_program).map_err(LeoError::Anyhow))?;
 
             // Add the bytecode to the import stubs.
-            let stub =
-                handler.extend_if_error(disassemble_from_str::<CurrentNetwork>(&program_name, &bytecode).map_err(|err| err.into()))?;
+            let stub = handler.extend_if_error(
+                disassemble_from_str::<CurrentNetwork>(&program_name, &bytecode).map_err(|err| err.into()),
+            )?;
             import_stubs.insert(Symbol::intern(&program_name), stub);
 
             // Hash the ast files.

--- a/compiler/compiler/tests/execute.rs
+++ b/compiler/compiler/tests/execute.rs
@@ -185,7 +185,7 @@ fn run_test(test: Test, handler: &Handler, buf: &BufferEmitter) -> Result<Value,
 
             // Add the bytecode to the import stubs.
             let stub =
-                handler.extend_if_error(disassemble_from_str::<CurrentNetwork>(&bytecode).map_err(|err| err.into()))?;
+                handler.extend_if_error(disassemble_from_str::<CurrentNetwork>(&program_name, &bytecode).map_err(|err| err.into()))?;
             import_stubs.insert(Symbol::intern(&program_name), stub);
 
             // Hash the ast files.

--- a/compiler/compiler/tests/execute.rs
+++ b/compiler/compiler/tests/execute.rs
@@ -184,8 +184,9 @@ fn run_test(test: Test, handler: &Handler, buf: &BufferEmitter) -> Result<Value,
             }
 
             // Add the bytecode to the import stubs.
-            let stub =
-                handler.extend_if_error(disassemble_from_str::<CurrentNetwork>(&program_name, &bytecode).map_err(|err| err.into()))?;
+            let stub = handler.extend_if_error(
+                disassemble_from_str::<CurrentNetwork>(&program_name, &bytecode).map_err(|err| err.into()),
+            )?;
             import_stubs.insert(Symbol::intern(&program_name), stub);
 
             // Hash the ast files.

--- a/errors/src/errors/utils/util_errors.rs
+++ b/errors/src/errors/utils/util_errors.rs
@@ -51,7 +51,7 @@ create_messages!(
     snarkvm_parsing_error {
         args: (name: impl Display),
         msg: format!("Failed to parse the source file for `{name}.aleo` into a valid Aleo program."),
-        help: Some("Make sure that you are using the correct `--network` and `--endpoint` options.".to_string()),
+        help: None,
     }
 
     @formatted

--- a/errors/src/errors/utils/util_errors.rs
+++ b/errors/src/errors/utils/util_errors.rs
@@ -49,9 +49,9 @@ create_messages!(
 
     @formatted
     snarkvm_parsing_error {
-        args: (),
-        msg: "SnarkVM failure to parse `.aleo` program".to_string(),
-        help: None,
+        args: (name: impl Display),
+        msg: format!("Failed to parse the source file for `{name}.aleo` into a valid Aleo program."),
+        help: Some("Make sure that you are using the correct `--network` and `--endpoint` options.".to_string()),
     }
 
     @formatted

--- a/leo/cli/commands/query/mod.rs
+++ b/leo/cli/commands/query/mod.rs
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm::circuit::{AleoTestnetV0, AleoV0};
-use snarkvm::prelude::{MainnetV0, TestnetV0};
 use super::*;
+use snarkvm::prelude::{MainnetV0, TestnetV0};
 
 mod block;
 use block::Block;
@@ -43,7 +42,7 @@ mod utils;
 use utils::*;
 
 use leo_errors::UtilError;
-use leo_retriever::{fetch_from_network, NetworkName, verify_valid_program};
+use leo_retriever::{fetch_from_network, verify_valid_program, NetworkName};
 
 ///  Query live data from the Aleo network.
 #[derive(Parser, Debug)]
@@ -82,39 +81,35 @@ impl Command for Query {
             NetworkName::TestnetV0 => handle_query::<TestnetV0>(self, context),
         }
     }
-
 }
 
 // A helper function to handle the `query` command.
 fn handle_query<N: Network>(query: Query, context: Context) -> Result<<Query as Command>::Output> {
     let recursive = context.recursive;
-    let (program, output, ) = match query.command {
+    let (program, output) = match query.command {
         QueryCommands::Block { command } => (None, command.apply(context, ())?),
         QueryCommands::Transaction { command } => (None, command.apply(context, ())?),
         QueryCommands::Program { command } => {
             // Check if querying for program source code.
-            let program = if command.mappings || command.mapping_value.is_some() {
-                None
-            } else {
-                Some(command.name.clone())
-            };
+            let program =
+                if command.mappings || command.mapping_value.is_some() { None } else { Some(command.name.clone()) };
             (program, command.apply(context, ())?)
-        },
+        }
         QueryCommands::Stateroot { command } => (None, command.apply(context, ())?),
         QueryCommands::Committee { command } => (None, command.apply(context, ())?),
         QueryCommands::Mempool { command } => {
             if query.endpoint == "https://api.explorer.aleo.org/v1" {
                 tracing::warn!(
-                        "⚠️  `leo query mempool` is only valid when using a custom endpoint. Specify one using `--endpoint`."
-                    );
+                    "⚠️  `leo query mempool` is only valid when using a custom endpoint. Specify one using `--endpoint`."
+                );
             }
             (None, command.apply(context, ())?)
         }
         QueryCommands::Peers { command } => {
             if query.endpoint == "https://api.explorer.aleo.org/v1" {
                 tracing::warn!(
-                        "⚠️  `leo query peers` is only valid when using a custom endpoint. Specify one using `--endpoint`."
-                    );
+                    "⚠️  `leo query peers` is only valid when using a custom endpoint. Specify one using `--endpoint`."
+                );
             }
             (None, command.apply(context, ())?)
         }

--- a/utils/disassembler/src/lib.rs
+++ b/utils/disassembler/src/lib.rs
@@ -124,7 +124,8 @@ mod tests {
         create_session_if_not_set_then(|_| {
             let program_from_file =
                 fs::read_to_string("../tmp/.aleo/registry/mainnet/zk_bitwise_stack_v0_0_2.aleo").unwrap();
-            let _program = disassemble_from_str::<CurrentNetwork>("zk_bitwise_stack_v0_0_2", &program_from_file).unwrap();
+            let _program =
+                disassemble_from_str::<CurrentNetwork>("zk_bitwise_stack_v0_0_2", &program_from_file).unwrap();
         });
     }
 }

--- a/utils/disassembler/src/lib.rs
+++ b/utils/disassembler/src/lib.rs
@@ -86,10 +86,10 @@ pub fn disassemble<N: Network, Instruction: InstructionTrait<N>, Command: Comman
     }
 }
 
-pub fn disassemble_from_str<N: Network>(program: &str) -> Result<Stub, UtilError> {
+pub fn disassemble_from_str<N: Network>(name: &str, program: &str) -> Result<Stub, UtilError> {
     match Program::<N>::from_str(program) {
         Ok(p) => Ok(disassemble(p)),
-        Err(_) => Err(UtilError::snarkvm_parsing_error(Default::default())),
+        Err(_) => Err(UtilError::snarkvm_parsing_error(name, Default::default())),
     }
 }
 
@@ -124,7 +124,7 @@ mod tests {
         create_session_if_not_set_then(|_| {
             let program_from_file =
                 fs::read_to_string("../tmp/.aleo/registry/mainnet/zk_bitwise_stack_v0_0_2.aleo").unwrap();
-            let _program = disassemble_from_str::<CurrentNetwork>(&program_from_file).unwrap();
+            let _program = disassemble_from_str::<CurrentNetwork>("zk_bitwise_stack_v0_0_2", &program_from_file).unwrap();
         });
     }
 }

--- a/utils/retriever/src/retriever/mod.rs
+++ b/utils/retriever/src/retriever/mod.rs
@@ -517,8 +517,8 @@ fn retrieve_from_network<N: Network>(
 }
 
 // Fetch the given endpoint url and return the sanitized response.
-pub fn fetch_from_network(url: &String) -> Result<String, UtilError> {
-    let response = ureq::get(&url.clone())
+pub fn fetch_from_network(url: &str) -> Result<String, UtilError> {
+    let response = ureq::get(url)
         .set(&format!("X-Aleo-Leo-{}", env!("CARGO_PKG_VERSION")), "true")
         .call()
         .map_err(|err| UtilError::failed_to_retrieve_from_endpoint(err, Default::default()))?;
@@ -530,7 +530,7 @@ pub fn fetch_from_network(url: &String) -> Result<String, UtilError> {
 }
 
 // Verify that a fetched program is valid aleo instructions.
-pub fn verify_valid_program<N: Network>(name: &String, program: &String) -> Result<(), UtilError> {
+pub fn verify_valid_program<N: Network>(name: &str, program: &str) -> Result<(), UtilError> {
     match Program::<N>::from_str(program) {
         Ok(_) => Ok(()),
         Err(_) => Err(UtilError::snarkvm_parsing_error(name, Default::default())),

--- a/utils/retriever/src/retriever/mod.rs
+++ b/utils/retriever/src/retriever/mod.rs
@@ -31,8 +31,8 @@ use std::{
     io::Read,
     marker::PhantomData,
     path::{Path, PathBuf},
+    str::FromStr,
 };
-use std::str::FromStr;
 
 // Retriever is responsible for retrieving external programs
 pub struct Retriever<N: Network> {
@@ -440,7 +440,7 @@ fn retrieve_from_network<N: Network>(
     // Check if the file is already cached in `~/.aleo/registry/{network}/{program}`
     let move_to_path = home_path.join(network.to_string());
     let path = move_to_path.join(name.clone());
-    let mut file_str: String;
+    let file_str: String;
     if !path.exists() {
         // Create directories along the way if they don't exist
         std::fs::create_dir_all(&move_to_path).map_err(|err| {
@@ -454,7 +454,7 @@ fn retrieve_from_network<N: Network>(
         // Fetch from network
         println!("Retrieving {name} from {endpoint} on {network}.");
         file_str = fetch_from_network(&format!("{endpoint}/{network}/program/{}", &name))?;
-        verify_valid_program::<N>(&name, &file_str)?;
+        verify_valid_program::<N>(name, &file_str)?;
         println!("Successfully retrieved {} from {:?}!", name, endpoint);
 
         // Write file to cache
@@ -516,7 +516,7 @@ fn retrieve_from_network<N: Network>(
     ))
 }
 
-// Fetch the given endpoint url and return the sanitized response. 
+// Fetch the given endpoint url and return the sanitized response.
 pub fn fetch_from_network(url: &String) -> Result<String, UtilError> {
     let response = ureq::get(&url.clone())
         .set(&format!("X-Aleo-Leo-{}", env!("CARGO_PKG_VERSION")), "true")


### PR DESCRIPTION
Resolves #27977 and #27982. 

Details:
- Modularizes network retrievals. This way we are not maintaining two separate components for network retrievals, as previously we had both `leo query` and `retriever`.
- Previously network requests yielding responses like `Too Many Requests! Wait for 355256s` were being erroneously inserted into the `.aleo/registry` cache of network dependencies. This PR ensures that all fetched aleo programs are valid programs.