### PR TITLE
[Feat] CLI cleanup

### DIFF
--- a/.circleci/token/run.sh
+++ b/.circleci/token/run.sh
@@ -56,6 +56,7 @@ leo run mint_public aleo13ssze66adjjkt795z9u5wpq8h6kn0y2657726h4h3e3wfnez4vqsm30
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Privately mint 100 tokens for Bob.
@@ -125,6 +126,7 @@ leo run transfer_public aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqy
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Privately transfer 20 tokens from Bob to Alice.
@@ -199,6 +201,7 @@ leo run transfer_public_to_private aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Convert 40 private tokens from Bob into 40 public tokens for Alice.

--- a/.circleci/token/run.sh
+++ b/.circleci/token/run.sh
@@ -21,7 +21,7 @@ fi
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Publicly mint 100 tokens for Alice.
@@ -56,7 +56,7 @@ leo run mint_public aleo13ssze66adjjkt795z9u5wpq8h6kn0y2657726h4h3e3wfnez4vqsm30
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Privately mint 100 tokens for Bob.
@@ -91,7 +91,7 @@ leo run mint_private aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqyshd
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Publicly transfer 10 tokens from Alice to Bob.
@@ -126,7 +126,7 @@ leo run transfer_public aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqy
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Privately transfer 20 tokens from Bob to Alice.
@@ -165,7 +165,7 @@ leo run transfer_private "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Convert 30 public tokens from Alice into 30 private tokens for Bob.
@@ -201,7 +201,7 @@ leo run transfer_public_to_private aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Convert 40 private tokens from Bob into 40 public tokens for Alice.
@@ -243,5 +243,5 @@ leo run transfer_private_to_public "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env

--- a/.circleci/token/run.sh
+++ b/.circleci/token/run.sh
@@ -21,6 +21,7 @@ fi
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Publicly mint 100 tokens for Alice.
@@ -89,6 +90,7 @@ leo run mint_private aleo17vy26rpdhqx4598y5gp7nvaa9rk7tnvl6ufhvvf4calsrrqdaqyshd
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Publicly transfer 10 tokens from Alice to Bob.
@@ -161,6 +163,7 @@ leo run transfer_private "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Convert 30 public tokens from Alice into 30 private tokens for Bob.
@@ -237,4 +240,5 @@ leo run transfer_private_to_public "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2851,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2910,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2935,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2945,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2955,7 +2955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -2973,12 +2973,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3019,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3098,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3135,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3146,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3209,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3253,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3286,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "rand",
  "rayon",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "anyhow",
  "rand",
@@ -3364,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3408,7 +3408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3459,7 +3459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3472,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3501,7 +3501,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "anyhow",
  "colored",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -3529,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3552,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3577,7 +3577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3630,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "bincode",
  "once_cell",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=8a05317#8a053177f46dc4383d5a8adcc6b14e4c73f34c82"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1557,7 @@ dependencies = [
  "colored",
  "console",
  "crossterm",
+ "dialoguer",
  "dirs 5.0.1",
  "dotenvy",
  "indexmap 1.9.3",
@@ -1582,6 +1596,7 @@ name = "leo-package"
 version = "1.12.0"
 dependencies = [
  "aleo-std",
+ "dialoguer",
  "indexmap 1.9.3",
  "lazy_static",
  "leo-errors",
@@ -2739,6 +2754,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "enum_index"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2860,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2890,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2904,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2915,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2925,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2935,7 +2955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -2953,12 +2973,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2969,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -2984,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2999,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3012,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3021,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3031,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3043,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3055,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3066,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3078,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3091,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3102,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3115,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3126,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3149,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3167,8 +3187,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
+ "enum-iterator",
  "enum_index",
  "enum_index_derive",
  "indexmap 2.2.6",
@@ -3188,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3203,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3214,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3222,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3232,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3243,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3254,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3265,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3276,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "rand",
  "rayon",
@@ -3290,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3307,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3331,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "rand",
@@ -3343,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3362,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3374,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3387,7 +3408,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3400,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3412,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3423,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3438,7 +3459,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3451,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3460,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3480,7 +3501,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "anyhow",
  "colored",
@@ -3495,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -3508,7 +3529,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3531,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3556,7 +3577,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3566,6 +3587,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
+ "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -3585,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3608,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -3622,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "bincode",
  "once_cell",
@@ -3635,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3656,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=fddd8b9#fddd8b92b4c6417e37d62722b3b937534dc4fb26"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=6d64025#6d64025f3f775fa164d70d9a8177ec93c97cd36e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 [workspace.dependencies.snarkvm]
 #version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "6d64025"
+rev = "8a05317"
 
 [lib]
 path = "leo/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 [workspace.dependencies.snarkvm]
 #version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "fddd8b9"
+rev = "6d64025"
 
 [lib]
 path = "leo/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ ci_skip = [ "leo-compiler/ci_skip" ]
 noconfig = [ ]
 
 [dependencies]
+dialoguer = "0.11.0"
 num-format = "0.4.4"
 text-tables = "0.3.1"
 ureq = "2.9.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 [workspace.dependencies.snarkvm]
 #version = "0.16.19"
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "8a05317"
+rev = "d170a9f"
 
 [lib]
 path = "leo/lib.rs"

--- a/compiler/compiler/tests/utilities/mod.rs
+++ b/compiler/compiler/tests/utilities/mod.rs
@@ -284,5 +284,3 @@ pub fn compile_and_process<'a>(parsed: &'a mut Compiler<'a, CurrentNetwork>) -> 
 
     Ok(bytecode)
 }
-
-

--- a/compiler/compiler/tests/utilities/mod.rs
+++ b/compiler/compiler/tests/utilities/mod.rs
@@ -138,7 +138,7 @@ pub fn setup_build_directory(
     let _manifest_file = Manifest::create(&directory, &program_id).unwrap();
 
     // Create the environment file.
-    Env::<CurrentNetwork>::new(None, endpoint).unwrap().write_to(&directory).unwrap();
+    Env::<CurrentNetwork>::new(None, endpoint).unwrap().write_to(&directory);
     if Env::<CurrentNetwork>::exists_at(&directory) {
         println!(".env file created at {:?}", &directory);
     }

--- a/compiler/compiler/tests/utilities/mod.rs
+++ b/compiler/compiler/tests/utilities/mod.rs
@@ -121,6 +121,7 @@ pub fn setup_build_directory(
     program_name: &str,
     bytecode: &String,
     handler: &Handler,
+    endpoint: String,
 ) -> Result<Package<CurrentNetwork>, ()> {
     // Initialize a temporary directory.
     let directory = temp_dir();
@@ -137,7 +138,7 @@ pub fn setup_build_directory(
     let _manifest_file = Manifest::create(&directory, &program_id).unwrap();
 
     // Create the environment file.
-    Env::<CurrentNetwork>::new().unwrap().write_to(&directory).unwrap();
+    Env::<CurrentNetwork>::new(None, endpoint).unwrap().write_to(&directory).unwrap();
     if Env::<CurrentNetwork>::exists_at(&directory) {
         println!(".env file created at {:?}", &directory);
     }

--- a/compiler/compiler/tests/utilities/mod.rs
+++ b/compiler/compiler/tests/utilities/mod.rs
@@ -285,13 +285,4 @@ pub fn compile_and_process<'a>(parsed: &'a mut Compiler<'a, CurrentNetwork>) -> 
     Ok(bytecode)
 }
 
-/// Returns the private key from the .env file specified in the directory.
-#[allow(unused)]
-pub fn dotenv_private_key(directory: &Path) -> Result<PrivateKey<CurrentNetwork>> {
-    use std::str::FromStr;
-    dotenvy::from_path(directory.join(".env")).map_err(|_| anyhow!("Missing a '.env' file in the test directory."))?;
-    // Load the private key from the environment.
-    let private_key = dotenvy::var("PRIVATE_KEY").map_err(|e| anyhow!("Missing PRIVATE_KEY - {e}"))?;
-    // Parse the private key.
-    PrivateKey::<CurrentNetwork>::from_str(&private_key)
-}
+

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -267,23 +267,23 @@ create_messages!(
 
     @backtraced
     failed_to_get_endpoint_from_env {
-        args: (command: impl Display),
+        args: (),
         msg: "Failed to get an endpoint.".to_string(),
-        help: Some(format!("Either make sure you have a `.env` file in current project directory with an `ENDPOINT` variable set, or set the `--endpoint` flag when invoking the CLI command.\n Example: `ENDPOINT=https://api.explorer.aleo.org/v1` or `leo {command} --endpoint \"https://api.explorer.aleo.org/v1\"`.")),
+        help: Some("Either make sure you have a `.env` file in current project directory with an `ENDPOINT` variable set, or set the `--endpoint` flag when invoking the CLI command.\n Example: `ENDPOINT=https://api.explorer.aleo.org/v1` or `leo build --endpoint \"https://api.explorer.aleo.org/v1\"`.".to_string()),
     }
 
     @backtraced
     failed_to_get_private_key_from_env {
-        args: (command: impl Display),
+        args: (),
         msg: "Failed to get a private key.".to_string(),
-        help: Some(format!("Either make sure you have a `.env` file in current project directory with a `PRIVATE_KEY` variable set, or set the `--private-key` flag when invoking the CLI command.\n Example: `PRIVATE_KEY=0x1234...` or `leo {command} --private-key \"APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH\"`.")),
+        help: Some("Either make sure you have a `.env` file in current project directory with a `PRIVATE_KEY` variable set, or set the `--private-key` flag when invoking the CLI command.\n Example: `PRIVATE_KEY=0x1234...` or `leo deploy --private-key \"APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH\"`.".to_string()),
     }
 
     @backtraced
     failed_to_get_network_from_env {
-        args: (command: impl Display),
+        args: (),
         msg: "Failed to get a network.".to_string(),
-        help: Some(format!("Either make sure you have a `.env` file in current project directory with a `NETWORK` variable set, or set the `--network` flag when invoking the CLI command.\n Example: `NETWORK=testnet` or `leo {command} --network testnet`.")),
+        help: Some("Either make sure you have a `.env` file in current project directory with a `NETWORK` variable set, or set the `--network` flag when invoking the CLI command.\n Example: `NETWORK=testnet` or `leo build --network testnet`.".to_string()),
     }
 
     @backtraced
@@ -299,4 +299,12 @@ create_messages!(
         msg: format!("Program `{program}` exceeds the variable limit {limit} for deployment on network {network}."),
         help: Some("Reduce the number of variables in the program by reducing the number of instructions in transition functions.".to_string()),
     }
+
+    @backtraced
+    confirmation_failed {
+        args: (),
+        msg: "Failed to confirm transaction".to_string(),
+        help: None,
+    }
+
 );

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -285,4 +285,18 @@ create_messages!(
         msg: "Failed to get a network.".to_string(),
         help: Some(format!("Either make sure you have a `.env` file in current project directory with a `NETWORK` variable set, or set the `--network` flag when invoking the CLI command.\n Example: `NETWORK=testnet` or `leo {command} --network testnet`.")),
     }
+    
+    @backtraced
+    constraint_limit_exceeded {
+        args: (program: impl Display, limit: u64, network: impl Display),
+        msg: format!("Program `{program}` exceeds the constraint limit {limit} for deployment on network {network}."),
+        help: Some("Reduce the number of constraints in the program by reducing the number of instructions in transition functions.".to_string()),
+    }
+    
+    @backtraced
+    variable_limit_exceeded {
+        args: (program: impl Display, limit: u64, network: impl Display),
+        msg: format!("Program `{program}` exceeds the variable limit {limit} for deployment on network {network}."),
+        help: Some("Reduce the number of variables in the program by reducing the number of instructions in transition functions.".to_string()),
+    }
 );

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -306,14 +306,14 @@ create_messages!(
         msg: "Failed to confirm transaction".to_string(),
         help: None,
     }
-    
+
     @backtraced
     invalid_balance {
         args: (account: impl Display),
         msg: format!("Invalid public balance for account: {account}"),
         help: Some("Make sure the account has enough balance to pay for the deployment.".to_string()),
     }
-    
+
     @backtraced
     table_render_failed {
         args: (error: impl Display),

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -306,5 +306,11 @@ create_messages!(
         msg: "Failed to confirm transaction".to_string(),
         help: None,
     }
-
+    
+    @backtraced
+    invalid_balance {
+        args: (account: impl Display),
+        msg: format!("Invalid public balance for account: {account}"),
+        help: Some("Make sure the account has enough balance to pay for the deployment.".to_string()),
+    }
 );

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -313,4 +313,11 @@ create_messages!(
         msg: format!("Invalid public balance for account: {account}"),
         help: Some("Make sure the account has enough balance to pay for the deployment.".to_string()),
     }
+    
+    @backtraced
+    table_render_failed {
+        args: (error: impl Display),
+        msg: format!("Failed to render table.\nError: {error}"),
+        help: None,
+    }
 );

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -264,35 +264,35 @@ create_messages!(
         msg: format!("{error}"),
         help: None,
     }
-    
+
     @backtraced
     failed_to_get_endpoint_from_env {
         args: (command: impl Display),
         msg: "Failed to get an endpoint.".to_string(),
         help: Some(format!("Either make sure you have a `.env` file in current project directory with an `ENDPOINT` variable set, or set the `--endpoint` flag when invoking the CLI command.\n Example: `ENDPOINT=https://api.explorer.aleo.org/v1` or `leo {command} --endpoint \"https://api.explorer.aleo.org/v1\"`.")),
     }
-    
+
     @backtraced
     failed_to_get_private_key_from_env {
         args: (command: impl Display),
         msg: "Failed to get a private key.".to_string(),
         help: Some(format!("Either make sure you have a `.env` file in current project directory with a `PRIVATE_KEY` variable set, or set the `--private-key` flag when invoking the CLI command.\n Example: `PRIVATE_KEY=0x1234...` or `leo {command} --private-key \"APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH\"`.")),
     }
-    
+
     @backtraced
     failed_to_get_network_from_env {
         args: (command: impl Display),
         msg: "Failed to get a network.".to_string(),
         help: Some(format!("Either make sure you have a `.env` file in current project directory with a `NETWORK` variable set, or set the `--network` flag when invoking the CLI command.\n Example: `NETWORK=testnet` or `leo {command} --network testnet`.")),
     }
-    
+
     @backtraced
     constraint_limit_exceeded {
         args: (program: impl Display, limit: u64, network: impl Display),
         msg: format!("Program `{program}` exceeds the constraint limit {limit} for deployment on network {network}."),
         help: Some("Reduce the number of constraints in the program by reducing the number of instructions in transition functions.".to_string()),
     }
-    
+
     @backtraced
     variable_limit_exceeded {
         args: (program: impl Display, limit: u64, network: impl Display),

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -264,4 +264,25 @@ create_messages!(
         msg: format!("{error}"),
         help: None,
     }
+    
+    @backtraced
+    failed_to_get_endpoint_from_env {
+        args: (command: impl Display),
+        msg: "Failed to get an endpoint.".to_string(),
+        help: Some(format!("Either make sure you have a `.env` file in current project directory with an `ENDPOINT` variable set, or set the `--endpoint` flag when invoking the CLI command.\n Example: `ENDPOINT=https://api.explorer.aleo.org/v1` or `leo {command} --endpoint \"https://api.explorer.aleo.org/v1\"`.")),
+    }
+    
+    @backtraced
+    failed_to_get_private_key_from_env {
+        args: (command: impl Display),
+        msg: "Failed to get a private key.".to_string(),
+        help: Some(format!("Either make sure you have a `.env` file in current project directory with a `PRIVATE_KEY` variable set, or set the `--private-key` flag when invoking the CLI command.\n Example: `PRIVATE_KEY=0x1234...` or `leo {command} --private-key \"APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH\"`.")),
+    }
+    
+    @backtraced
+    failed_to_get_network_from_env {
+        args: (command: impl Display),
+        msg: "Failed to get a network.".to_string(),
+        help: Some(format!("Either make sure you have a `.env` file in current project directory with a `NETWORK` variable set, or set the `--network` flag when invoking the CLI command.\n Example: `NETWORK=testnet` or `leo {command} --network testnet`.")),
+    }
 );

--- a/errors/src/errors/mod.rs
+++ b/errors/src/errors/mod.rs
@@ -109,7 +109,7 @@ impl LeoError {
             FlattenError(error) => error.error_code(),
             UtilError(error) => error.error_code(),
             LastErrorCode(_) => unreachable!(),
-            Anyhow(_) => unimplemented!(), // todo: implement error codes for snarkvm errors.
+            Anyhow(_) => "SnarkVM Error".to_string(), // todo: implement error codes for snarkvm errors.
         }
     }
 
@@ -128,7 +128,7 @@ impl LeoError {
             FlattenError(error) => error.exit_code(),
             UtilError(error) => error.exit_code(),
             LastErrorCode(code) => *code,
-            Anyhow(_) => unimplemented!(), // todo: implement exit codes for snarkvm errors.
+            Anyhow(_) => 11000, // todo: implement exit codes for snarkvm errors.
         }
     }
 }

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -418,4 +418,18 @@ create_messages!(
         msg: format!("❌ Execution error: {error}"),
         help: Some("Make sure that you are using the right `--network` options.".to_string()),
     }
+
+    @backtraced
+    snarkvm_error {
+        args: (error: impl Display),
+        msg: format!("{error}"),
+        help: None,
+    }
+
+    @backtraced
+    failed_to_load_package {
+        args: (path: impl Display),
+        msg: format!("Failed to load leo project at path {path}"),
+        help: Some("Make sure that the path is correct and that the project exists.".to_string()),
+    }
 );

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -422,7 +422,7 @@ create_messages!(
     @backtraced
     snarkvm_error {
         args: (error: impl Display),
-        msg: format!("{error}"),
+        msg: format!("[snarkVM Error] {error}"),
         help: None,
     }
 

--- a/errors/src/errors/utils/util_errors.rs
+++ b/errors/src/errors/utils/util_errors.rs
@@ -193,4 +193,11 @@ create_messages!(
         msg: format!("Invalid field: {field}."),
         help: Some("Field element must be numerical string with optional \"field\" suffix.".to_string()),
     }
+    
+    @backtraced
+    invalid_bound {
+        args: (bound: impl Display),
+        msg: format!("Invalid bound: {bound}."),
+        help: Some("Bound must be a valid u32.".to_string()),
+    }
 );

--- a/errors/src/errors/utils/util_errors.rs
+++ b/errors/src/errors/utils/util_errors.rs
@@ -193,7 +193,7 @@ create_messages!(
         msg: format!("Invalid field: {field}."),
         help: Some("Field element must be numerical string with optional \"field\" suffix.".to_string()),
     }
-    
+
     @backtraced
     invalid_bound {
         args: (bound: impl Display),

--- a/examples/auction/.env
+++ b/examples/auction/.env
@@ -1,4 +1,4 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/auction/.env
+++ b/examples/auction/.env
@@ -1,4 +1,4 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/auction/run.sh
+++ b/examples/auction/run.sh
@@ -63,6 +63,7 @@ leo run place_bid aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9p
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Have the second bidder place a bid of 90.
@@ -85,6 +86,7 @@ leo run place_bid aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2GUmKbVsuc1NSj28pa1WTQuZaK5f1DQJAT6vPcHyWokG
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Have the auctioneer select the winning bid.

--- a/examples/auction/run.sh
+++ b/examples/auction/run.sh
@@ -40,7 +40,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Have the first bidder place a bid of 10.
@@ -63,7 +63,7 @@ leo run place_bid aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9p
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Have the second bidder place a bid of 90.
@@ -86,7 +86,7 @@ leo run place_bid aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2GUmKbVsuc1NSj28pa1WTQuZaK5f1DQJAT6vPcHyWokG
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Have the auctioneer select the winning bid.
@@ -144,7 +144,7 @@ leo run finish "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 

--- a/examples/auction/run.sh
+++ b/examples/auction/run.sh
@@ -40,6 +40,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Have the first bidder place a bid of 10.
@@ -141,6 +142,7 @@ leo run finish "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 

--- a/examples/basic_bank/.env
+++ b/examples/basic_bank/.env
@@ -2,4 +2,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
 ENDPOINT=https://api.explorer.aleo.org/v1
-

--- a/examples/basic_bank/.env
+++ b/examples/basic_bank/.env
@@ -1,4 +1,5 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 

--- a/examples/basic_bank/.env
+++ b/examples/basic_bank/.env
@@ -1,4 +1,4 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/basic_bank/run.sh
+++ b/examples/basic_bank/run.sh
@@ -20,7 +20,7 @@ fi
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Have the bank issue 100 tokens to the user.
@@ -71,7 +71,7 @@ leo run issue aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t 10
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Have the user deposit 50 tokens into the bank.
@@ -166,7 +166,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Have the bank withdraw all of the user's tokens with compound interest over 15 periods at 12.34%.

--- a/examples/basic_bank/run.sh
+++ b/examples/basic_bank/run.sh
@@ -20,6 +20,7 @@ fi
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Have the bank issue 100 tokens to the user.
@@ -164,6 +165,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Have the bank withdraw all of the user's tokens with compound interest over 15 periods at 12.34%.

--- a/examples/basic_bank/run.sh
+++ b/examples/basic_bank/run.sh
@@ -71,6 +71,7 @@ leo run issue aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t 10
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Have the user deposit 50 tokens into the bank.

--- a/examples/battleship/.env
+++ b/examples/battleship/.env
@@ -1,5 +1,5 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 

--- a/examples/battleship/.env
+++ b/examples/battleship/.env
@@ -1,4 +1,5 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 

--- a/examples/battleship/run.sh
+++ b/examples/battleship/run.sh
@@ -19,7 +19,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 echo "✅ Successfully initialized Player 1."
@@ -70,7 +70,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 leo run initialize_board 31u64 2207646875648u64 224u64 9042383626829824u64 aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t || exit
@@ -119,7 +119,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 leo run play '{
@@ -155,7 +155,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 leo run play '{
@@ -191,7 +191,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 leo run play '{
@@ -227,7 +227,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 leo run play '{
@@ -256,5 +256,5 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env

--- a/examples/battleship/run.sh
+++ b/examples/battleship/run.sh
@@ -19,6 +19,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 echo "✅ Successfully initialized Player 1."
@@ -117,6 +118,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 leo run play '{
@@ -187,6 +189,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 leo run play '{
@@ -250,4 +253,5 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env

--- a/examples/battleship/run.sh
+++ b/examples/battleship/run.sh
@@ -70,6 +70,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 leo run initialize_board 31u64 2207646875648u64 224u64 9042383626829824u64 aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem2u4t || exit
@@ -154,6 +155,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 leo run play '{
@@ -225,6 +227,7 @@ echo "
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 leo run play '{

--- a/examples/bubblesort/.env
+++ b/examples/bubblesort/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/bubblesort/.env
+++ b/examples/bubblesort/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/core/.env
+++ b/examples/core/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/core/.env
+++ b/examples/core/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/fibonacci/.env
+++ b/examples/fibonacci/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/fibonacci/.env
+++ b/examples/fibonacci/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/groups/.env
+++ b/examples/groups/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/groups/.env
+++ b/examples/groups/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzdebruijn/.env
+++ b/examples/hackers-delight/ntzdebruijn/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzdebruijn/.env
+++ b/examples/hackers-delight/ntzdebruijn/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzgaudet/.env
+++ b/examples/hackers-delight/ntzgaudet/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzgaudet/.env
+++ b/examples/hackers-delight/ntzgaudet/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzloops/.env
+++ b/examples/hackers-delight/ntzloops/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzloops/.env
+++ b/examples/hackers-delight/ntzloops/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzmasks/.env
+++ b/examples/hackers-delight/ntzmasks/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzmasks/.env
+++ b/examples/hackers-delight/ntzmasks/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzreisers/.env
+++ b/examples/hackers-delight/ntzreisers/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzreisers/.env
+++ b/examples/hackers-delight/ntzreisers/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzseals/.env
+++ b/examples/hackers-delight/ntzseals/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzseals/.env
+++ b/examples/hackers-delight/ntzseals/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzsearchtree/.env
+++ b/examples/hackers-delight/ntzsearchtree/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzsearchtree/.env
+++ b/examples/hackers-delight/ntzsearchtree/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/hackers-delight/ntzsmallvals/.env
+++ b/examples/hackers-delight/ntzsmallvals/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/hackers-delight/ntzsmallvals/.env
+++ b/examples/hackers-delight/ntzsmallvals/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/helloworld/.env
+++ b/examples/helloworld/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/helloworld/.env
+++ b/examples/helloworld/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/interest/.env
+++ b/examples/interest/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/interest/.env
+++ b/examples/interest/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/lottery/.env
+++ b/examples/lottery/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/lottery/.env
+++ b/examples/lottery/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/message/.env
+++ b/examples/message/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/message/.env
+++ b/examples/message/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/simple_token/.env
+++ b/examples/simple_token/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/simple_token/.env
+++ b/examples/simple_token/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/tictactoe/.env
+++ b/examples/tictactoe/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/tictactoe/.env
+++ b/examples/tictactoe/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/token/.env
+++ b/examples/token/.env
@@ -2,4 +2,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
 ENDPOINT=https://api.explorer.aleo.org/v1
-

--- a/examples/token/.env
+++ b/examples/token/.env
@@ -1,4 +1,5 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 

--- a/examples/token/.env
+++ b/examples/token/.env
@@ -1,4 +1,4 @@
 
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/token/run.sh
+++ b/examples/token/run.sh
@@ -20,6 +20,7 @@ fi
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Publicly mint 100 tokens for Alice.
@@ -88,6 +89,7 @@ leo run mint_private aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Publicly transfer 10 tokens from Alice to Bob.
@@ -160,6 +162,7 @@ leo run transfer_private "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Convert 30 public tokens from Alice into 30 private tokens for Bob.
@@ -236,4 +239,5 @@ leo run transfer_private_to_public "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env

--- a/examples/token/run.sh
+++ b/examples/token/run.sh
@@ -20,7 +20,7 @@ fi
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Publicly mint 100 tokens for Alice.
@@ -55,7 +55,7 @@ leo run mint_public aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Privately mint 100 tokens for Bob.
@@ -90,7 +90,7 @@ leo run mint_private aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5pqem
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Publicly transfer 10 tokens from Alice to Bob.
@@ -125,7 +125,7 @@ leo run transfer_public aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5p
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Privately transfer 20 tokens from Bob to Alice.
@@ -164,7 +164,7 @@ leo run transfer_private "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Convert 30 public tokens from Alice into 30 private tokens for Bob.
@@ -200,7 +200,7 @@ leo run transfer_public_to_private aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0x
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env
 
 # Convert 40 private tokens from Bob into 40 public tokens for Alice.
@@ -242,5 +242,5 @@ leo run transfer_private_to_public "{
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030
 " > .env

--- a/examples/token/run.sh
+++ b/examples/token/run.sh
@@ -55,6 +55,7 @@ leo run mint_public aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Privately mint 100 tokens for Bob.
@@ -124,6 +125,7 @@ leo run transfer_public aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0xzqqw29q9m5p
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Privately transfer 20 tokens from Bob to Alice.
@@ -198,6 +200,7 @@ leo run transfer_public_to_private aleo1s3ws5tra87fjycnjrwsjcrnw2qxr8jfqqdugnf0x
 echo "
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh
+ENDPOINT=https://api.explorer.aleo.org/v1
 " > .env
 
 # Convert 40 private tokens from Bob into 40 public tokens for Alice.

--- a/examples/twoadicity/.env
+++ b/examples/twoadicity/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/twoadicity/.env
+++ b/examples/twoadicity/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/examples/vote/.env
+++ b/examples/vote/.env
@@ -1,2 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
+ENDPOINT=https://api.explorer.aleo.org/v1

--- a/examples/vote/.env
+++ b/examples/vote/.env
@@ -1,3 +1,3 @@
 NETWORK=mainnet
 PRIVATE_KEY=APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH
-ENDPOINT=https://api.explorer.aleo.org/v1
+ENDPOINT=https://localhost:3030

--- a/leo/cli/cli.rs
+++ b/leo/cli/cli.rs
@@ -315,6 +315,7 @@ mod test_helpers {
     use std::path::Path;
 
     const NETWORK: &str = "mainnet";
+    const ENDPOINT: &str = "https://api.explorer.aleo.org/v1";
 
     pub(crate) fn sample_nested_package(temp_dir: &Path) {
         let name = "nested";
@@ -329,7 +330,9 @@ mod test_helpers {
         let new = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: name.to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New { name: name.to_string(), network: NETWORK.to_string(), endpoint: ENDPOINT.to_string() },
+            },
             path: Some(project_directory.clone()),
             home: None,
         };
@@ -430,7 +433,13 @@ function external_nested_function:
         let create_grandparent_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "grandparent".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "grandparent".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(grandparent_directory.clone()),
             home: None,
         };
@@ -438,7 +447,13 @@ function external_nested_function:
         let create_parent_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "parent".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "parent".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(parent_directory.clone()),
             home: None,
         };
@@ -446,7 +461,13 @@ function external_nested_function:
         let create_child_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "child".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "child".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(child_directory.clone()),
             home: None,
         };
@@ -561,7 +582,13 @@ program child.aleo {
         let create_outer_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "outer".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "outer".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(outer_directory.clone()),
             home: None,
         };
@@ -569,7 +596,13 @@ program child.aleo {
         let create_inner_1_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "inner_1".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "inner_1".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(inner_1_directory.clone()),
             home: None,
         };
@@ -577,7 +610,13 @@ program child.aleo {
         let create_inner_2_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "inner_2".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "inner_2".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(inner_2_directory.clone()),
             home: None,
         };
@@ -699,7 +738,13 @@ program outer.aleo {
         let create_outer_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "outer_2".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "outer_2".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(outer_directory.clone()),
             home: None,
         };
@@ -707,7 +752,13 @@ program outer.aleo {
         let create_inner_1_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "inner_1".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "inner_1".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(inner_1_directory.clone()),
             home: None,
         };
@@ -715,7 +766,13 @@ program outer.aleo {
         let create_inner_2_project = CLI {
             debug: false,
             quiet: false,
-            command: Commands::New { command: New { name: "inner_2".to_string(), network: NETWORK.to_string() } },
+            command: Commands::New {
+                command: New {
+                    name: "inner_2".to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
+            },
             path: Some(inner_2_directory.clone()),
             home: None,
         };

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -152,6 +152,7 @@ impl Command for Account {
                 match network {
                     NetworkName::MainnetV0 => generate_new_account::<MainnetV0>(seed, write, discreet, &ctx, endpoint),
                     NetworkName::TestnetV0 => generate_new_account::<TestnetV0>(seed, write, discreet, &ctx, endpoint),
+                    NetworkName::CanaryV0 => generate_new_account::<MainnetV0>(seed, write, discreet, &ctx, endpoint),
                 }?
             }
             Account::Import { private_key, write, discreet, network, endpoint } => {
@@ -160,6 +161,7 @@ impl Command for Account {
                 match network {
                     NetworkName::MainnetV0 => import_account::<MainnetV0>(private_key, write, discreet, &ctx, endpoint),
                     NetworkName::TestnetV0 => import_account::<TestnetV0>(private_key, write, discreet, &ctx, endpoint),
+                    NetworkName::CanaryV0 => import_account::<MainnetV0>(private_key, write, discreet, &ctx, endpoint),
                 }?
             }
             Self::Sign { message, seed, raw, private_key, private_key_file, network, endpoint: _ } => {
@@ -172,6 +174,9 @@ impl Command for Account {
                     NetworkName::TestnetV0 => {
                         sign_message::<TestnetV0>(message, seed, raw, private_key, private_key_file)
                     }
+                    NetworkName::CanaryV0 => {
+                        sign_message::<MainnetV0>(message, seed, raw, private_key, private_key_file)
+                    }
                 }?;
                 println!("{result}")
             }
@@ -181,6 +186,7 @@ impl Command for Account {
                 let result = match network {
                     NetworkName::MainnetV0 => verify_message::<MainnetV0>(address, signature, message, raw),
                     NetworkName::TestnetV0 => verify_message::<TestnetV0>(address, signature, message, raw),
+                    NetworkName::CanaryV0 => verify_message::<MainnetV0>(address, signature, message, raw),
                 }?;
                 println!("{result}")
             }

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -26,7 +26,7 @@ use crossterm::ExecutableCommand;
 use leo_retriever::NetworkName;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
-use snarkvm::prelude::{MainnetV0, Network, TestnetV0};
+use snarkvm::prelude::{CanaryV0, MainnetV0, Network, TestnetV0};
 use std::{
     io::{self, Read, Write},
     path::PathBuf,
@@ -96,13 +96,6 @@ pub enum Account {
         raw: bool,
         #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
         network: String,
-        #[clap(
-            short = 'e',
-            long,
-            help = "Endpoint to retrieve network state from.",
-            default_value = "https://api.explorer.aleo.org/v1"
-        )]
-        endpoint: String,
     },
     /// Verify a message from an Aleo address.
     Verify {
@@ -120,13 +113,6 @@ pub enum Account {
         raw: bool,
         #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
         network: String,
-        #[clap(
-            short = 'e',
-            long,
-            help = "Endpoint to retrieve network state from.",
-            default_value = "https://api.explorer.aleo.org/v1"
-        )]
-        endpoint: String,
     },
 }
 
@@ -152,7 +138,7 @@ impl Command for Account {
                 match network {
                     NetworkName::MainnetV0 => generate_new_account::<MainnetV0>(seed, write, discreet, &ctx, endpoint),
                     NetworkName::TestnetV0 => generate_new_account::<TestnetV0>(seed, write, discreet, &ctx, endpoint),
-                    NetworkName::CanaryV0 => generate_new_account::<MainnetV0>(seed, write, discreet, &ctx, endpoint),
+                    NetworkName::CanaryV0 => generate_new_account::<CanaryV0>(seed, write, discreet, &ctx, endpoint),
                 }?
             }
             Account::Import { private_key, write, discreet, network, endpoint } => {
@@ -161,10 +147,10 @@ impl Command for Account {
                 match network {
                     NetworkName::MainnetV0 => import_account::<MainnetV0>(private_key, write, discreet, &ctx, endpoint),
                     NetworkName::TestnetV0 => import_account::<TestnetV0>(private_key, write, discreet, &ctx, endpoint),
-                    NetworkName::CanaryV0 => import_account::<MainnetV0>(private_key, write, discreet, &ctx, endpoint),
+                    NetworkName::CanaryV0 => import_account::<CanaryV0>(private_key, write, discreet, &ctx, endpoint),
                 }?
             }
-            Self::Sign { message, seed, raw, private_key, private_key_file, network, endpoint: _ } => {
+            Self::Sign { message, seed, raw, private_key, private_key_file, network } => {
                 // Parse the network.
                 let network = NetworkName::try_from(network.as_str())?;
                 let result = match network {
@@ -180,13 +166,13 @@ impl Command for Account {
                 }?;
                 println!("{result}")
             }
-            Self::Verify { address, signature, message, raw, network, endpoint: _ } => {
+            Self::Verify { address, signature, message, raw, network } => {
                 // Parse the network.
                 let network = NetworkName::try_from(network.as_str())?;
                 let result = match network {
                     NetworkName::MainnetV0 => verify_message::<MainnetV0>(address, signature, message, raw),
                     NetworkName::TestnetV0 => verify_message::<TestnetV0>(address, signature, message, raw),
-                    NetworkName::CanaryV0 => verify_message::<MainnetV0>(address, signature, message, raw),
+                    NetworkName::CanaryV0 => verify_message::<CanaryV0>(address, signature, message, raw),
                 }?;
                 println!("{result}")
             }

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -49,6 +49,13 @@ pub enum Account {
         discreet: bool,
         #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
         network: String,
+        #[clap(
+            short = 'e',
+            long,
+            help = "Endpoint to retrieve network state from.",
+            default_value = "https://api.explorer.aleo.org/v1"
+        )]
+        endpoint: String,
     },
     /// Derive an Aleo account from a private key.
     Import {
@@ -62,6 +69,13 @@ pub enum Account {
         discreet: bool,
         #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
         network: String,
+        #[clap(
+            short = 'e',
+            long,
+            help = "Endpoint to retrieve network state from.",
+            default_value = "https://api.explorer.aleo.org/v1"
+        )]
+        endpoint: String,
     },
     /// Sign a message using your Aleo private key.
     Sign {
@@ -82,6 +96,13 @@ pub enum Account {
         raw: bool,
         #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
         network: String,
+        #[clap(
+            short = 'e',
+            long,
+            help = "Endpoint to retrieve network state from.",
+            default_value = "https://api.explorer.aleo.org/v1"
+        )]
+        endpoint: String,
     },
     /// Verify a message from an Aleo address.
     Verify {
@@ -99,6 +120,13 @@ pub enum Account {
         raw: bool,
         #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
         network: String,
+        #[clap(
+            short = 'e',
+            long,
+            help = "Endpoint to retrieve network state from.",
+            default_value = "https://api.explorer.aleo.org/v1"
+        )]
+        endpoint: String,
     },
 }
 
@@ -118,23 +146,23 @@ impl Command for Account {
         Self: Sized,
     {
         match self {
-            Account::New { seed, write, discreet, network } => {
+            Account::New { seed, write, discreet, network, endpoint } => {
                 // Parse the network.
                 let network = NetworkName::try_from(network.as_str())?;
                 match network {
-                    NetworkName::MainnetV0 => generate_new_account::<MainnetV0>(seed, write, discreet, &ctx),
-                    NetworkName::TestnetV0 => generate_new_account::<TestnetV0>(seed, write, discreet, &ctx),
+                    NetworkName::MainnetV0 => generate_new_account::<MainnetV0>(seed, write, discreet, &ctx, endpoint),
+                    NetworkName::TestnetV0 => generate_new_account::<TestnetV0>(seed, write, discreet, &ctx, endpoint),
                 }?
             }
-            Account::Import { private_key, write, discreet, network } => {
+            Account::Import { private_key, write, discreet, network, endpoint } => {
                 // Parse the network.
                 let network = NetworkName::try_from(network.as_str())?;
                 match network {
-                    NetworkName::MainnetV0 => import_account::<MainnetV0>(private_key, write, discreet, &ctx),
-                    NetworkName::TestnetV0 => import_account::<TestnetV0>(private_key, write, discreet, &ctx),
+                    NetworkName::MainnetV0 => import_account::<MainnetV0>(private_key, write, discreet, &ctx, endpoint),
+                    NetworkName::TestnetV0 => import_account::<TestnetV0>(private_key, write, discreet, &ctx, endpoint),
                 }?
             }
-            Self::Sign { message, seed, raw, private_key, private_key_file, network } => {
+            Self::Sign { message, seed, raw, private_key, private_key_file, network, endpoint: _ } => {
                 // Parse the network.
                 let network = NetworkName::try_from(network.as_str())?;
                 let result = match network {
@@ -147,7 +175,7 @@ impl Command for Account {
                 }?;
                 println!("{result}")
             }
-            Self::Verify { address, signature, message, raw, network } => {
+            Self::Verify { address, signature, message, raw, network, endpoint: _ } => {
                 // Parse the network.
                 let network = NetworkName::try_from(network.as_str())?;
                 let result = match network {
@@ -164,7 +192,13 @@ impl Command for Account {
 // Helper functions
 
 // Generate a new account.
-fn generate_new_account<N: Network>(seed: Option<u64>, write: bool, discreet: bool, ctx: &Context) -> Result<()> {
+fn generate_new_account<N: Network>(
+    seed: Option<u64>,
+    write: bool,
+    discreet: bool,
+    ctx: &Context,
+    endpoint: String,
+) -> Result<()> {
     // Sample a new Aleo account.
     let private_key = match seed {
         // Recover the field element deterministically.
@@ -179,13 +213,19 @@ fn generate_new_account<N: Network>(seed: Option<u64>, write: bool, discreet: bo
 
     // Save key data to .env file.
     if write {
-        write_to_env_file(private_key, ctx)?;
+        write_to_env_file(private_key, ctx, endpoint)?;
     }
     Ok(())
 }
 
 // Import an account.
-fn import_account<N: Network>(private_key: Option<String>, write: bool, discreet: bool, ctx: &Context) -> Result<()> {
+fn import_account<N: Network>(
+    private_key: Option<String>,
+    write: bool,
+    discreet: bool,
+    ctx: &Context,
+    endpoint: String,
+) -> Result<()> {
     let priv_key = match discreet {
         true => {
             let private_key_input = rpassword::prompt_password("Please enter your private key: ").unwrap();
@@ -207,7 +247,7 @@ fn import_account<N: Network>(private_key: Option<String>, write: bool, discreet
 
     // Save key data to .env file.
     if write {
-        write_to_env_file::<N>(priv_key, ctx)?;
+        write_to_env_file::<N>(priv_key, ctx, endpoint)?;
     }
 
     Ok(())
@@ -323,9 +363,9 @@ pub(crate) fn verify_message<N: Network>(
 }
 
 // Write the network and private key to the .env file in project directory.
-fn write_to_env_file<N: Network>(private_key: PrivateKey<N>, ctx: &Context) -> Result<()> {
+fn write_to_env_file<N: Network>(private_key: PrivateKey<N>, ctx: &Context, endpoint: String) -> Result<()> {
     let program_dir = ctx.dir()?;
-    Env::<N>::from(private_key).write_to(&program_dir)?;
+    Env::<N>::new(Some(private_key), endpoint)?.write_to(&program_dir)?;
     tracing::info!("✅ Private Key written to {}", program_dir.join(".env").display());
     Ok(())
 }

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -93,7 +93,7 @@ impl Command for Build {
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Parse the network.
-        let network = NetworkName::try_from(self.options.network.as_str())?;
+        let network = NetworkName::try_from(context.get_network(&self.options.network, "build")?)?;
         match network {
             NetworkName::MainnetV0 => handle_build::<MainnetV0>(&self, context),
             NetworkName::TestnetV0 => handle_build::<TestnetV0>(&self, context),
@@ -123,7 +123,7 @@ fn handle_build<N: Network>(command: &Build, context: Context) -> Result<<Build 
 
     // Retrieve all local dependencies in post order
     let main_sym = Symbol::intern(&program_id.name().to_string());
-    let mut retriever = Retriever::<N>::new(main_sym, &package_path, &home_path, command.options.endpoint.clone())
+    let mut retriever = Retriever::<N>::new(main_sym, &package_path, &home_path, context.get_endpoint(&command.options.endpoint, "build")?.to_string())
         .map_err(|err| UtilError::failed_to_retrieve_dependencies(err, Default::default()))?;
     let mut local_dependencies =
         retriever.retrieve().map_err(|err| UtilError::failed_to_retrieve_dependencies(err, Default::default()))?;

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -97,6 +97,7 @@ impl Command for Build {
         match network {
             NetworkName::MainnetV0 => handle_build::<MainnetV0>(&self, context),
             NetworkName::TestnetV0 => handle_build::<TestnetV0>(&self, context),
+            NetworkName::CanaryV0 => handle_build::<MainnetV0>(&self, context),
         }
     }
 }
@@ -123,8 +124,13 @@ fn handle_build<N: Network>(command: &Build, context: Context) -> Result<<Build 
 
     // Retrieve all local dependencies in post order
     let main_sym = Symbol::intern(&program_id.name().to_string());
-    let mut retriever = Retriever::<N>::new(main_sym, &package_path, &home_path, context.get_endpoint(&command.options.endpoint, "build")?.to_string())
-        .map_err(|err| UtilError::failed_to_retrieve_dependencies(err, Default::default()))?;
+    let mut retriever = Retriever::<N>::new(
+        main_sym,
+        &package_path,
+        &home_path,
+        context.get_endpoint(&command.options.endpoint, "build")?.to_string(),
+    )
+    .map_err(|err| UtilError::failed_to_retrieve_dependencies(err, Default::default()))?;
     let mut local_dependencies =
         retriever.retrieve().map_err(|err| UtilError::failed_to_retrieve_dependencies(err, Default::default()))?;
 

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -29,6 +29,7 @@ use snarkvm::{
 };
 
 use indexmap::IndexMap;
+use snarkvm::prelude::CanaryV0;
 use std::{
     io::Write,
     path::{Path, PathBuf},
@@ -93,11 +94,11 @@ impl Command for Build {
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Parse the network.
-        let network = NetworkName::try_from(context.get_network(&self.options.network, "build")?)?;
+        let network = NetworkName::try_from(context.get_network(&self.options.network)?)?;
         match network {
             NetworkName::MainnetV0 => handle_build::<MainnetV0>(&self, context),
             NetworkName::TestnetV0 => handle_build::<TestnetV0>(&self, context),
-            NetworkName::CanaryV0 => handle_build::<MainnetV0>(&self, context),
+            NetworkName::CanaryV0 => handle_build::<CanaryV0>(&self, context),
         }
     }
 }
@@ -128,7 +129,7 @@ fn handle_build<N: Network>(command: &Build, context: Context) -> Result<<Build 
         main_sym,
         &package_path,
         &home_path,
-        context.get_endpoint(&command.options.endpoint, "build")?.to_string(),
+        context.get_endpoint(&command.options.endpoint)?.to_string(),
     )
     .map_err(|err| UtilError::failed_to_retrieve_dependencies(err, Default::default()))?;
     let mut local_dependencies =

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -120,6 +120,15 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
 
         // Generate the deployment
         let deployment = package.deploy::<A>(None)?;
+        
+        // Check if the number of variables and constraints are within the limits.
+        if deployment.num_combined_variables()? > N::MAX_DEPLOYMENT_VARIABLES {
+            return Err(CliError::variable_limit_exceeded(name, N::MAX_DEPLOYMENT_VARIABLES, network).into());
+        } 
+        if deployment.num_combined_constraints()? > N::MAX_DEPLOYMENT_CONSTRAINTS {
+            return Err(CliError::constraint_limit_exceeded(name, N::MAX_DEPLOYMENT_CONSTRAINTS, network).into());
+        }
+        
         let deployment_id = deployment.to_deployment_id()?;
 
         let store = ConsensusStore::<N, ConsensusMemory<N>>::open(StorageMode::Production)?;

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -148,7 +148,7 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
             synthesis_cost as f64 / 1_000_000.0,
             namespace_cost as f64 / 1_000_000.0,
             command.fee_options.priority_fee as f64 / 1_000_000.0,
-        );
+        )?;
 
         // Initialize an RNG.
         let rng = &mut rand::thread_rng();
@@ -240,7 +240,7 @@ fn deploy_cost_breakdown(
         ["Total", &format!("{:.6}", total_cost)],
     ];
     let mut out = Vec::new();
-    text_tables::render(&mut out, data).map_err(|err| CliError::table_render_failed(err))?;
-    println!("{}", ::std::str::from_utf8(&out).map_err(|err| CliError::table_render_failed(err))?);
+    text_tables::render(&mut out, data).map_err(CliError::table_render_failed)?;
+    println!("{}", ::std::str::from_utf8(&out).map_err(CliError::table_render_failed)?);
     Ok(())
 }

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -228,7 +228,7 @@ fn deploy_cost_breakdown(
     synthesis_cost: f64,
     namespace_cost: f64,
     priority_fee: f64,
-) {
+) -> Result<()> {
     println!("\nBase deployment cost for '{}' is {} credits.\n", name.bold(), total_cost);
     // Display the cost breakdown in a table.
     let data = [
@@ -240,6 +240,7 @@ fn deploy_cost_breakdown(
         ["Total", &format!("{:.6}", total_cost)],
     ];
     let mut out = Vec::new();
-    text_tables::render(&mut out, data).unwrap();
-    println!("{}", ::std::str::from_utf8(&out).unwrap());
+    text_tables::render(&mut out, data).map_err(|err| CliError::table_render_failed(err))?;
+    println!("{}", ::std::str::from_utf8(&out).map_err(|err| CliError::table_render_failed(err))?);
+    Ok(())
 }

--- a/leo/cli/commands/example.rs
+++ b/leo/cli/commands/example.rs
@@ -25,6 +25,13 @@ pub struct Example {
     pub(crate) name: String,
     #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
     pub(crate) network: String,
+    #[clap(
+        short = 'e',
+        long,
+        help = "Endpoint to retrieve network state from.",
+        default_value = "https://api.explorer.aleo.org/v1"
+    )]
+    pub(crate) endpoint: String,
 }
 
 impl Command for Example {
@@ -33,7 +40,8 @@ impl Command for Example {
 
     fn prelude(&self, context: Context) -> Result<Self::Input> {
         // Run leo new <name> --network <network>
-        (New { name: self.name.clone(), network: self.network.clone() }).execute(context)
+        (New { name: self.name.clone(), network: self.network.clone(), endpoint: self.endpoint.clone() })
+            .execute(context)
     }
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output>

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -172,8 +172,7 @@ fn handle_execute<A: Aleo>(
 
         // Load the main program, and all of its imports.
         let program_id = &ProgramID::<A::Network>::from_str(&format!("{}.aleo", program_name))?;
-        // TODO: X
-        load_program_from_network(&command, context.clone(), &mut vm.process().write(), program_id, network, endpoint)?;
+        load_program_from_network(context.clone(), &mut vm.process().write(), program_id, network, endpoint)?;
 
         let fee_record = if let Some(record) = command.fee_options.record {
             Some(parse_record(&private_key, &record)?)
@@ -322,7 +321,6 @@ fn handle_execute<A: Aleo>(
 
 /// A helper function to recursively load the program and all of its imports into the process. Lifted from snarkOS.
 fn load_program_from_network<N: Network>(
-    command: &Execute,
     context: Context,
     process: &mut Process<N>,
     program_id: &ProgramID<N>,
@@ -354,7 +352,7 @@ fn load_program_from_network<N: Network>(
         // Add the imports to the process if does not exist yet.
         if !process.contains_program(import_program_id) {
             // Recursively load the program and its imports.
-            load_program_from_network(command, context.clone(), process, import_program_id, network, endpoint)?;
+            load_program_from_network(context.clone(), process, import_program_id, network, endpoint)?;
         }
     }
 

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -207,7 +207,7 @@ fn handle_execute<A: Aleo>(
             storage_cost as f64 / 1_000_000.0,
             finalize_cost as f64 / 1_000_000.0,
             command.fee_options.priority_fee as f64 / 1_000_000.0,
-        );
+        )?;
 
         // Check if the public balance is sufficient.
         if fee_record.is_none() {
@@ -261,7 +261,13 @@ fn handle_execute<A: Aleo>(
     }
     // Execute the request.
     let (response, execution, metrics) = package
-        .execute::<A, _>(endpoint.to_string(), &private_key, Identifier::try_from(command.name.clone())?, &parsed_inputs, rng)
+        .execute::<A, _>(
+            endpoint.to_string(),
+            &private_key,
+            Identifier::try_from(command.name.clone())?,
+            &parsed_inputs,
+            rng,
+        )
         .map_err(PackageError::execution_error)?;
 
     let fee = None;
@@ -369,7 +375,13 @@ fn load_program_from_network<N: Network>(
 }
 
 // A helper function to display a cost breakdown of the execution.
-fn execution_cost_breakdown(name: &String, total_cost: f64, storage_cost: f64, finalize_cost: f64, priority_fee: f64) -> Result<()> {
+fn execution_cost_breakdown(
+    name: &String,
+    total_cost: f64,
+    storage_cost: f64,
+    finalize_cost: f64,
+    priority_fee: f64,
+) -> Result<()> {
     println!("\nBase execution cost for '{}' is {} credits.\n", name.bold(), total_cost);
     // Display the cost breakdown in a table.
     let data = [
@@ -380,7 +392,7 @@ fn execution_cost_breakdown(name: &String, total_cost: f64, storage_cost: f64, f
         ["Total", &format!("{:.6}", total_cost)],
     ];
     let mut out = Vec::new();
-    text_tables::render(&mut out, data).map_err(|err| CliError::table_render_failed(err))?;
-    println!("{}", std::str::from_utf8(&out).map_err(|err| CliError::table_render_failed(err))?);
+    text_tables::render(&mut out, data).map_err(CliError::table_render_failed)?;
+    println!("{}", std::str::from_utf8(&out).map_err(CliError::table_render_failed)?);
     Ok(())
 }

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -210,6 +210,8 @@ impl Default for BuildOptions {
 /// Used by Execute and Deploy commands.
 #[derive(Parser, Clone, Debug, Default)]
 pub struct FeeOptions {
+    #[clap(short, long, help = "Don't ask for confirmation.", default_value = "false")]
+    pub(crate) yes: bool,
     #[clap(short, long, help = "Performs a dry-run of transaction generation")]
     pub(crate) dry_run: bool,
     #[clap(long, help = "Priority fee in microcredits. Defaults to 0.", default_value = "0")]
@@ -273,7 +275,7 @@ fn check_balance<N: Network>(
 
 /// Determine if the transaction should be broadcast or displayed to user.
 fn handle_broadcast<N: Network>(endpoint: &String, transaction: Transaction<N>, operation: &String) -> Result<()> {
-    println!("Broadcasting transaction to {}...", endpoint.clone());
+    println!("Broadcasting transaction to {}...\n", endpoint.clone());
     // Get the transaction id.
     let transaction_id = transaction.id();
 
@@ -287,20 +289,20 @@ fn handle_broadcast<N: Network>(endpoint: &String, transaction: Transaction<N>, 
             match transaction {
                 Transaction::Deploy(..) => {
                     println!(
-                        "⌛ Deployment {transaction_id} ('{}') has been broadcast to {}.",
+                        "⌛ Deployment {transaction_id} ('{}') has been broadcast to {}.\n",
                         operation.bold(),
                         endpoint
                     )
                 }
                 Transaction::Execute(..) => {
                     println!(
-                        "⌛ Execution {transaction_id} ('{}') has been broadcast to {}.",
+                        "⌛ Execution {transaction_id} ('{}') has been broadcast to {}.\n",
                         operation.bold(),
                         endpoint
                     )
                 }
                 Transaction::Fee(..) => {
-                    println!("❌ Failed to broadcast fee '{}' to the {}.", operation.bold(), endpoint)
+                    println!("❌ Failed to broadcast fee '{}' to the {}.\n", operation.bold(), endpoint)
                 }
             }
             Ok(())

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -135,12 +135,10 @@ pub trait Command {
 pub struct BuildOptions {
     #[clap(
         long,
-        help = "Endpoint to retrieve network state from.",
-        default_value = "https://api.explorer.aleo.org/v1"
-    )]
-    pub endpoint: String,
-    #[clap(long, help = "Network to broadcast to. Defaults to mainnet.", default_value = "mainnet")]
-    pub(crate) network: String,
+        help = "Endpoint to retrieve network state from. Overrides setting in `.env`.")]
+    pub endpoint: Option<String>,
+    #[clap(long, help = "Network to broadcast to. Overrides setting in `.env`.")] 
+    pub(crate) network: Option<String>,
     #[clap(long, help = "Does not recursively compile dependencies.")]
     pub non_recursive: bool,
     #[clap(long, help = "Enables offline mode.")]
@@ -182,8 +180,8 @@ pub struct BuildOptions {
 impl Default for BuildOptions {
     fn default() -> Self {
         Self {
-            endpoint: "http://api.explorer.aleo.org/v1".to_string(),
-            network: "mainnet".to_string(),
+            endpoint: None,
+            network:None,
             non_recursive: false,
             offline: false,
             enable_symbol_table_spans: false,
@@ -252,8 +250,8 @@ fn check_balance<N: Network>(
     let address = Address::<N>::try_from(ViewKey::try_from(private_key)?)?;
     // Query the public balance of the address on the `account` mapping from `credits.aleo`.
     let mut public_balance = Query {
-        endpoint: endpoint.to_string(),
-        network: network.to_string(),
+        endpoint: Some(endpoint.to_string()),
+        network: Some(network.to_string()),
         command: QueryCommands::Program {
             command: crate::cli::commands::query::Program {
                 name: "credits".to_string(),

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -264,9 +264,11 @@ fn check_balance<N: Network>(
     // Remove the last 3 characters since they represent the `u64` suffix.
     public_balance.truncate(public_balance.len() - 3);
     // Compare balance.
-    if public_balance.parse::<u64>().unwrap() < total_cost {
+    let balance = public_balance.parse::<u64>().unwrap();
+    if balance < total_cost {
         Err(PackageError::insufficient_balance(address, public_balance, total_cost).into())
     } else {
+        println!("Your current public balance is {} credits.\n", balance as f64 / 1_000_000.0);
         Ok(())
     }
 }

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -261,8 +261,9 @@ fn check_balance<N: Network>(
     .execute(Context::new(context.path.clone(), context.home.clone(), true)?)?;
     // Remove the last 3 characters since they represent the `u64` suffix.
     public_balance.truncate(public_balance.len() - 3);
-    // Compare balance.
+    // This unwrap is safe as the Query will error if it cannot retrieve a public balance, and if it returns a balance that will be a u64.
     let balance = public_balance.parse::<u64>().unwrap();
+    // Compare balance.
     if balance < total_cost {
         Err(PackageError::insufficient_balance(address, public_balance, total_cost).into())
     } else {

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -261,8 +261,12 @@ fn check_balance<N: Network>(
     .execute(Context::new(context.path.clone(), context.home.clone(), true)?)?;
     // Remove the last 3 characters since they represent the `u64` suffix.
     public_balance.truncate(public_balance.len() - 3);
-    // This unwrap is safe as the Query will error if it cannot retrieve a public balance, and if it returns a balance that will be a u64.
-    let balance = public_balance.parse::<u64>().unwrap();
+    // Make sure the balance is valid.
+    let balance = if let Ok(credits) = public_balance.parse::<u64>() {
+        credits
+    } else {
+        return Err(CliError::invalid_balance(address).into());
+    };
     // Compare balance.
     if balance < total_cost {
         Err(PackageError::insufficient_balance(address, public_balance, total_cost).into())

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -133,11 +133,9 @@ pub trait Command {
 /// require Build command output as their input.
 #[derive(Parser, Clone, Debug)]
 pub struct BuildOptions {
-    #[clap(
-        long,
-        help = "Endpoint to retrieve network state from. Overrides setting in `.env`.")]
+    #[clap(long, help = "Endpoint to retrieve network state from. Overrides setting in `.env`.")]
     pub endpoint: Option<String>,
-    #[clap(long, help = "Network to broadcast to. Overrides setting in `.env`.")] 
+    #[clap(long, help = "Network to broadcast to. Overrides setting in `.env`.")]
     pub(crate) network: Option<String>,
     #[clap(long, help = "Does not recursively compile dependencies.")]
     pub non_recursive: bool,
@@ -181,7 +179,7 @@ impl Default for BuildOptions {
     fn default() -> Self {
         Self {
             endpoint: None,
-            network:None,
+            network: None,
             non_recursive: false,
             offline: false,
             enable_symbol_table_spans: false,

--- a/leo/cli/commands/new.rs
+++ b/leo/cli/commands/new.rs
@@ -26,6 +26,13 @@ pub struct New {
     pub(crate) name: String,
     #[clap(short = 'n', long, help = "Name of the network to use", default_value = "mainnet")]
     pub(crate) network: String,
+    #[clap(
+        short = 'e',
+        long,
+        help = "Endpoint to retrieve network state from.",
+        default_value = "https://api.explorer.aleo.org/v1"
+    )]
+    pub(crate) endpoint: String,
 }
 
 impl Command for New {
@@ -53,8 +60,8 @@ impl Command for New {
 
         // Initialize the package.
         match network {
-            NetworkName::MainnetV0 => Package::initialize::<MainnetV0>(&self.name, &package_path),
-            NetworkName::TestnetV0 => Package::initialize::<TestnetV0>(&self.name, &package_path),
+            NetworkName::MainnetV0 => Package::initialize::<MainnetV0>(&self.name, &package_path, self.endpoint),
+            NetworkName::TestnetV0 => Package::initialize::<TestnetV0>(&self.name, &package_path, self.endpoint),
         }?;
 
         Ok(())

--- a/leo/cli/commands/new.rs
+++ b/leo/cli/commands/new.rs
@@ -62,6 +62,7 @@ impl Command for New {
         match network {
             NetworkName::MainnetV0 => Package::initialize::<MainnetV0>(&self.name, &package_path, self.endpoint),
             NetworkName::TestnetV0 => Package::initialize::<TestnetV0>(&self.name, &package_path, self.endpoint),
+            NetworkName::CanaryV0 => Package::initialize::<TestnetV0>(&self.name, &package_path, self.endpoint),
         }?;
 
         Ok(())

--- a/leo/cli/commands/new.rs
+++ b/leo/cli/commands/new.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use snarkvm::prelude::{MainnetV0, TestnetV0};
+use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 
 use leo_retriever::NetworkName;
 
@@ -62,7 +62,7 @@ impl Command for New {
         match network {
             NetworkName::MainnetV0 => Package::initialize::<MainnetV0>(&self.name, &package_path, self.endpoint),
             NetworkName::TestnetV0 => Package::initialize::<TestnetV0>(&self.name, &package_path, self.endpoint),
-            NetworkName::CanaryV0 => Package::initialize::<TestnetV0>(&self.name, &package_path, self.endpoint),
+            NetworkName::CanaryV0 => Package::initialize::<CanaryV0>(&self.name, &package_path, self.endpoint),
         }?;
 
         Ok(())

--- a/leo/cli/commands/query/block.rs
+++ b/leo/cli/commands/query/block.rs
@@ -69,8 +69,11 @@ impl Command for Block {
             is_valid_numerical_input(&range[0])?;
             is_valid_numerical_input(&range[1])?;
 
+            // Parse the range values.
+            let end = &range[1].parse::<u32>().map_err(|_| UtilError::invalid_bound(&range[1]))?;
+            let start = &range[0].parse::<u32>().map_err(|_| UtilError::invalid_bound(&range[0]))?;
             // Make sure the range is not too large.
-            if range[1].parse::<u32>().unwrap() - range[0].parse::<u32>().unwrap() > 50 {
+            if end - start > 50 {
                 return Err(UtilError::invalid_range().into());
             }
             format!("blocks?start={}&end={}", range[0], range[1])

--- a/leo/cli/commands/query/mod.rs
+++ b/leo/cli/commands/query/mod.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use snarkvm::prelude::{MainnetV0, TestnetV0};
+use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 
 mod block;
 use block::Block;
@@ -69,12 +69,12 @@ impl Command for Query {
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Parse the network.
-        let network = NetworkName::try_from(context.get_network(&self.network, "query")?)?;
-        let endpoint = context.get_endpoint(&self.endpoint, "query")?;
+        let network = NetworkName::try_from(context.get_network(&self.network)?)?;
+        let endpoint = context.get_endpoint(&self.endpoint)?;
         match network {
             NetworkName::MainnetV0 => handle_query::<MainnetV0>(self, context, &network.to_string(), &endpoint),
             NetworkName::TestnetV0 => handle_query::<TestnetV0>(self, context, &network.to_string(), &endpoint),
-            NetworkName::CanaryV0 => handle_query::<MainnetV0>(self, context, &network.to_string(), &endpoint),
+            NetworkName::CanaryV0 => handle_query::<CanaryV0>(self, context, &network.to_string(), &endpoint),
         }
     }
 }

--- a/leo/cli/commands/query/mod.rs
+++ b/leo/cli/commands/query/mod.rs
@@ -47,12 +47,7 @@ use leo_retriever::{fetch_from_network, verify_valid_program, NetworkName};
 ///  Query live data from the Aleo network.
 #[derive(Parser, Debug)]
 pub struct Query {
-    #[clap(
-        short,
-        long,
-        global = true,
-        help = "Endpoint to retrieve network state from. Defaults to entry in `.env`.",
-    )]
+    #[clap(short, long, global = true, help = "Endpoint to retrieve network state from. Defaults to entry in `.env`.")]
     pub endpoint: Option<String>,
     #[clap(short, long, global = true, help = "Network to use. Defaults to entry in `.env`.")]
     pub(crate) network: Option<String>,
@@ -79,12 +74,18 @@ impl Command for Query {
         match network {
             NetworkName::MainnetV0 => handle_query::<MainnetV0>(self, context, &network.to_string(), &endpoint),
             NetworkName::TestnetV0 => handle_query::<TestnetV0>(self, context, &network.to_string(), &endpoint),
+            NetworkName::CanaryV0 => handle_query::<MainnetV0>(self, context, &network.to_string(), &endpoint),
         }
     }
 }
 
 // A helper function to handle the `query` command.
-fn handle_query<N: Network>(query: Query, context: Context, network: &str, endpoint: &str) -> Result<<Query as Command>::Output> {
+fn handle_query<N: Network>(
+    query: Query,
+    context: Context,
+    network: &str,
+    endpoint: &str,
+) -> Result<<Query as Command>::Output> {
     let recursive = context.recursive;
     let (program, output) = match query.command {
         QueryCommands::Block { command } => (None, command.apply(context, ())?),

--- a/leo/cli/commands/run.rs
+++ b/leo/cli/commands/run.rs
@@ -19,7 +19,7 @@ use super::*;
 use leo_retriever::NetworkName;
 use snarkvm::{
     cli::Run as SnarkVMRun,
-    prelude::{MainnetV0, Network, Parser as SnarkVMParser, TestnetV0},
+    prelude::{CanaryV0, MainnetV0, Network, Parser as SnarkVMParser, TestnetV0},
 };
 
 /// Build, Prove and Run Leo program with inputs
@@ -52,11 +52,11 @@ impl Command for Run {
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Parse the network.
-        let network = NetworkName::try_from(context.get_network(&self.compiler_options.network, "run")?)?;
+        let network = NetworkName::try_from(context.get_network(&self.compiler_options.network)?)?;
         match network {
             NetworkName::MainnetV0 => handle_run::<MainnetV0>(self, context),
             NetworkName::TestnetV0 => handle_run::<TestnetV0>(self, context),
-            NetworkName::CanaryV0 => handle_run::<TestnetV0>(self, context),
+            NetworkName::CanaryV0 => handle_run::<CanaryV0>(self, context),
         }
     }
 }

--- a/leo/cli/commands/run.rs
+++ b/leo/cli/commands/run.rs
@@ -52,7 +52,7 @@ impl Command for Run {
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Parse the network.
-        let network = NetworkName::try_from(self.compiler_options.network.as_str())?;
+        let network = NetworkName::try_from(context.get_network(&self.compiler_options.network, "run")?)?;
         match network {
             NetworkName::MainnetV0 => handle_run::<MainnetV0>(self, context),
             NetworkName::TestnetV0 => handle_run::<TestnetV0>(self, context),

--- a/leo/cli/commands/run.rs
+++ b/leo/cli/commands/run.rs
@@ -56,6 +56,7 @@ impl Command for Run {
         match network {
             NetworkName::MainnetV0 => handle_run::<MainnetV0>(self, context),
             NetworkName::TestnetV0 => handle_run::<TestnetV0>(self, context),
+            NetworkName::CanaryV0 => handle_run::<TestnetV0>(self, context),
         }
     }
 }

--- a/leo/cli/helpers/context.rs
+++ b/leo/cli/helpers/context.rs
@@ -23,14 +23,14 @@ use snarkvm::file::Manifest;
 
 use aleo_std::aleo_dir;
 use indexmap::IndexMap;
-use snarkvm::prelude::{anyhow, Itertools, Network, PrivateKey};
+use snarkvm::prelude::{Itertools, Network, PrivateKey};
 use std::{
     env::current_dir,
     fs::File,
     io::Write,
     path::{Path, PathBuf},
+    str::FromStr,
 };
-use std::str::FromStr;
 
 /// Project context, manifest, current directory etc
 /// All the info that is relevant in most of the commands
@@ -144,27 +144,29 @@ impl Context {
 
     /// Returns the private key from the .env file specified in the directory.
     pub fn dotenv_private_key<N: Network>(&self, command: &str) -> Result<PrivateKey<N>> {
-        dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_private_key_from_env(command))?;
+        dotenvy::from_path(self.dir()?.join(".env"))
+            .map_err(|_| CliError::failed_to_get_private_key_from_env(command))?;
         // Load the private key from the environment.
-        let private_key = dotenvy::var("PRIVATE_KEY").map_err(|_| CliError::failed_to_get_private_key_from_env(command))?;
+        let private_key =
+            dotenvy::var("PRIVATE_KEY").map_err(|_| CliError::failed_to_get_private_key_from_env(command))?;
         // Parse the private key.
         Ok(PrivateKey::<N>::from_str(&private_key)?)
     }
-    
+
     /// Returns the endpoint from the .env file specified in the directory.
     pub fn dotenv_endpoint(&self, command: &str) -> Result<String> {
         dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_endpoint_from_env(command))?;
         // Load the endpoint from the environment.
         Ok(dotenvy::var("ENDPOINT").map_err(|_| CliError::failed_to_get_endpoint_from_env(command))?)
     }
-    
+
     /// Returns the network from the .env file specified in the directory.
     pub fn dotenv_network(&self, command: &str) -> Result<String> {
         dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_network_from_env(command))?;
         // Load the network from the environment.
         Ok(dotenvy::var("NETWORK").map_err(|_| CliError::failed_to_get_network_from_env(command))?)
     }
-    
+
     /// Returns the endpoint to interact with the network.
     /// If the `--endpoint` options is not provided, it will default to the one in the `.env` file.
     pub fn get_endpoint(&self, endpoint: &Option<String>, command: &str) -> Result<String> {
@@ -173,7 +175,7 @@ impl Context {
             None => Ok(self.dotenv_endpoint(command)?),
         }
     }
-    
+
     /// Returns the network name.
     /// If the `--network` options is not provided, it will default to the one in the `.env` file.
     pub fn get_network(&self, network: &Option<String>, command: &str) -> Result<String> {
@@ -182,12 +184,12 @@ impl Context {
             None => Ok(self.dotenv_network(command)?),
         }
     }
-    
+
     /// Returns the private key.
     /// If the `--private-key` options is not provided, it will default to the one in the `.env` file.
     pub fn get_private_key<N: Network>(&self, private_key: &Option<String>, command: &str) -> Result<PrivateKey<N>> {
         match private_key {
-            Some(private_key) => Ok(PrivateKey::<N>::from_str(&private_key)?),
+            Some(private_key) => Ok(PrivateKey::<N>::from_str(private_key)?),
             None => self.dotenv_private_key(command),
         }
     }

--- a/leo/cli/helpers/context.rs
+++ b/leo/cli/helpers/context.rs
@@ -143,54 +143,52 @@ impl Context {
     }
 
     /// Returns the private key from the .env file specified in the directory.
-    pub fn dotenv_private_key<N: Network>(&self, command: &str) -> Result<PrivateKey<N>> {
-        dotenvy::from_path(self.dir()?.join(".env"))
-            .map_err(|_| CliError::failed_to_get_private_key_from_env(command))?;
+    pub fn dotenv_private_key<N: Network>(&self) -> Result<PrivateKey<N>> {
+        dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_private_key_from_env())?;
         // Load the private key from the environment.
-        let private_key =
-            dotenvy::var("PRIVATE_KEY").map_err(|_| CliError::failed_to_get_private_key_from_env(command))?;
+        let private_key = dotenvy::var("PRIVATE_KEY").map_err(|_| CliError::failed_to_get_private_key_from_env())?;
         // Parse the private key.
         Ok(PrivateKey::<N>::from_str(&private_key)?)
     }
 
     /// Returns the endpoint from the .env file specified in the directory.
-    pub fn dotenv_endpoint(&self, command: &str) -> Result<String> {
-        dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_endpoint_from_env(command))?;
+    pub fn dotenv_endpoint(&self) -> Result<String> {
+        dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_endpoint_from_env())?;
         // Load the endpoint from the environment.
-        Ok(dotenvy::var("ENDPOINT").map_err(|_| CliError::failed_to_get_endpoint_from_env(command))?)
+        Ok(dotenvy::var("ENDPOINT").map_err(|_| CliError::failed_to_get_endpoint_from_env())?)
     }
 
     /// Returns the network from the .env file specified in the directory.
-    pub fn dotenv_network(&self, command: &str) -> Result<String> {
-        dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_network_from_env(command))?;
+    pub fn dotenv_network(&self) -> Result<String> {
+        dotenvy::from_path(self.dir()?.join(".env")).map_err(|_| CliError::failed_to_get_network_from_env())?;
         // Load the network from the environment.
-        Ok(dotenvy::var("NETWORK").map_err(|_| CliError::failed_to_get_network_from_env(command))?)
+        Ok(dotenvy::var("NETWORK").map_err(|_| CliError::failed_to_get_network_from_env())?)
     }
 
     /// Returns the endpoint to interact with the network.
     /// If the `--endpoint` options is not provided, it will default to the one in the `.env` file.
-    pub fn get_endpoint(&self, endpoint: &Option<String>, command: &str) -> Result<String> {
+    pub fn get_endpoint(&self, endpoint: &Option<String>) -> Result<String> {
         match endpoint {
             Some(endpoint) => Ok(endpoint.clone()),
-            None => Ok(self.dotenv_endpoint(command)?),
+            None => Ok(self.dotenv_endpoint()?),
         }
     }
 
     /// Returns the network name.
     /// If the `--network` options is not provided, it will default to the one in the `.env` file.
-    pub fn get_network(&self, network: &Option<String>, command: &str) -> Result<String> {
+    pub fn get_network(&self, network: &Option<String>) -> Result<String> {
         match network {
             Some(network) => Ok(network.clone()),
-            None => Ok(self.dotenv_network(command)?),
+            None => Ok(self.dotenv_network()?),
         }
     }
 
     /// Returns the private key.
     /// If the `--private-key` options is not provided, it will default to the one in the `.env` file.
-    pub fn get_private_key<N: Network>(&self, private_key: &Option<String>, command: &str) -> Result<PrivateKey<N>> {
+    pub fn get_private_key<N: Network>(&self, private_key: &Option<String>) -> Result<PrivateKey<N>> {
         match private_key {
             Some(private_key) => Ok(PrivateKey::<N>::from_str(private_key)?),
-            None => self.dotenv_private_key(command),
+            None => self.dotenv_private_key(),
         }
     }
 }

--- a/leo/cli/helpers/context.rs
+++ b/leo/cli/helpers/context.rs
@@ -23,7 +23,7 @@ use snarkvm::file::Manifest;
 
 use aleo_std::aleo_dir;
 use indexmap::IndexMap;
-use snarkvm::prelude::{Itertools, Network, PrivateKey};
+use snarkvm::prelude::{Network, PrivateKey};
 use std::{
     env::current_dir,
     fs::File,

--- a/leo/package/Cargo.toml
+++ b/leo/package/Cargo.toml
@@ -37,6 +37,9 @@ default-features = false
 version = "1.9"
 features = [ "serde" ]
 
+[dependencies.dialoguer]
+version = "0.11.0"
+
 [dependencies.num-format]
 version = "0.4.4"
 

--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -125,7 +125,7 @@ impl Package {
     }
 
     /// Creates a Leo package at the given path
-    pub fn initialize<N: Network>(package_name: &str, path: &Path) -> Result<()> {
+    pub fn initialize<N: Network>(package_name: &str, path: &Path, endpoint: String) -> Result<()> {
         // Construct the path to the package directory.
         let path = path.join(package_name);
 
@@ -147,7 +147,7 @@ impl Package {
         Gitignore::new().write_to(&path)?;
 
         // Create the .env file.
-        Env::<N>::new()?.write_to(&path)?;
+        Env::<N>::new(None, endpoint)?.write_to(&path)?;
 
         // Create a manifest.
         let manifest = Manifest::default(package_name);

--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -23,8 +23,7 @@ use leo_errors::{PackageError, Result};
 use leo_retriever::{Manifest, NetworkName};
 use serde::Deserialize;
 use snarkvm::prelude::{Network, PrivateKey};
-use std::path::Path;
-use std::str::FromStr;
+use std::{path::Path, str::FromStr};
 
 #[derive(Deserialize)]
 pub struct Package {
@@ -147,9 +146,13 @@ impl Package {
         // Create the .gitignore file.
         Gitignore::new().write_to(&path)?;
 
-        // Create the .env file. 
+        // Create the .env file.
         // Include the private key of validator 0 for ease of use with local devnets, as it will automatically be seeded with funds.
-        Env::<N>::new(Some(PrivateKey::<N>::from_str("APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH")?), endpoint)?.write_to(&path)?;
+        Env::<N>::new(
+            Some(PrivateKey::<N>::from_str("APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH")?),
+            endpoint,
+        )?
+        .write_to(&path)?;
 
         // Create a manifest.
         let manifest = Manifest::default(package_name);

--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -22,8 +22,9 @@ use leo_errors::{PackageError, Result};
 
 use leo_retriever::{Manifest, NetworkName};
 use serde::Deserialize;
-use snarkvm::prelude::Network;
+use snarkvm::prelude::{Network, PrivateKey};
 use std::path::Path;
+use std::str::FromStr;
 
 #[derive(Deserialize)]
 pub struct Package {
@@ -146,8 +147,9 @@ impl Package {
         // Create the .gitignore file.
         Gitignore::new().write_to(&path)?;
 
-        // Create the .env file.
-        Env::<N>::new(None, endpoint)?.write_to(&path)?;
+        // Create the .env file. 
+        // Include the private key of validator 0 for ease of use with local devnets, as it will automatically be seeded with funds.
+        Env::<N>::new(Some(PrivateKey::<N>::from_str("APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH")?), endpoint)?.write_to(&path)?;
 
         // Create a manifest.
         let manifest = Manifest::default(package_name);

--- a/leo/package/src/root/env.rs
+++ b/leo/package/src/root/env.rs
@@ -30,17 +30,21 @@ pub static ENV_FILENAME: &str = ".env";
 pub struct Env<N: Network> {
     #[serde(bound(deserialize = ""))]
     private_key: PrivateKey<N>,
+    endpoint: String,
 }
 
 impl<N: Network> Env<N> {
-    pub fn new() -> Result<Self> {
+    pub fn new(private_key: Option<PrivateKey<N>>, endpoint: String) -> Result<Self> {
         // Initialize an RNG.
         let rng = &mut rand::thread_rng();
 
         // Generate a development private key.
-        let private_key = PrivateKey::<N>::new(rng)?;
+        let private_key = match private_key {
+            Some(private_key) => private_key,
+            None => PrivateKey::<N>::new(rng)?,
+        };
 
-        Ok(Self { private_key })
+        Ok(Self { private_key, endpoint })
     }
 
     pub fn exists_at(path: &Path) -> bool {
@@ -63,12 +67,6 @@ impl<N: Network> Env<N> {
     }
 }
 
-impl<N: Network> From<PrivateKey<N>> for Env<N> {
-    fn from(private_key: PrivateKey<N>) -> Self {
-        Self { private_key }
-    }
-}
-
 impl<N: Network> ToString for Env<N> {
     fn to_string(&self) -> String {
         // Get the network name.
@@ -78,6 +76,6 @@ impl<N: Network> ToString for Env<N> {
             _ => unimplemented!("Unsupported network"),
         };
         // Return the formatted string.
-        format!("NETWORK={network}\nPRIVATE_KEY={}\n", self.private_key)
+        format!("NETWORK={network}\nPRIVATE_KEY={}\nENDPOINT={}\n", self.private_key, self.endpoint)
     }
 }

--- a/utils/retriever/src/program_context/manifest.rs
+++ b/utils/retriever/src/program_context/manifest.rs
@@ -87,7 +87,7 @@ impl Manifest {
     pub fn read_from_dir(path: &Path) -> Result<Self, PackageError> {
         // Read the manifest file.
         let contents = std::fs::read_to_string(path.join("program.json"))
-            .map_err(|err| PackageError::failed_to_read_file(path.to_str().unwrap(), err))?;
+            .map_err(|_| PackageError::failed_to_load_package(path.to_str().unwrap()))?;
         // Deserialize the manifest.
         serde_json::from_str(&contents)
             .map_err(|err| PackageError::failed_to_deserialize_manifest_file(path.to_str().unwrap(), err))

--- a/utils/retriever/src/program_context/network_name.rs
+++ b/utils/retriever/src/program_context/network_name.rs
@@ -16,7 +16,7 @@
 
 use leo_errors::{CliError, LeoError};
 use serde::{Deserialize, Serialize};
-use snarkvm::prelude::{MainnetV0, Network, TestnetV0};
+use snarkvm::prelude::{CanaryV0, MainnetV0, Network, TestnetV0};
 use std::fmt;
 
 // Retrievable networks for an external program
@@ -26,6 +26,8 @@ pub enum NetworkName {
     TestnetV0,
     #[serde(rename = "mainnet")]
     MainnetV0,
+    #[serde(rename = "canary")]
+    CanaryV0,
 }
 
 impl NetworkName {
@@ -33,6 +35,7 @@ impl NetworkName {
         match self {
             NetworkName::TestnetV0 => TestnetV0::ID,
             NetworkName::MainnetV0 => MainnetV0::ID,
+            NetworkName::CanaryV0 => CanaryV0::ID,
         }
     }
 }
@@ -44,6 +47,7 @@ impl TryFrom<&str> for NetworkName {
         match network {
             "testnet" => Ok(NetworkName::TestnetV0),
             "mainnet" => Ok(NetworkName::MainnetV0),
+            "canary" => Ok(NetworkName::CanaryV0),
             _ => Err(LeoError::CliError(CliError::invalid_network_name(network))),
         }
     }
@@ -56,6 +60,8 @@ impl TryFrom<String> for NetworkName {
             Ok(NetworkName::TestnetV0)
         } else if network == "mainnet" {
             Ok(NetworkName::MainnetV0)
+        } else if network == "canary" {
+            Ok(NetworkName::CanaryV0)
         } else {
             Err(LeoError::CliError(CliError::invalid_network_name(&network)))
         }
@@ -67,6 +73,7 @@ impl fmt::Display for NetworkName {
         match self {
             NetworkName::TestnetV0 => write!(f, "testnet"),
             NetworkName::MainnetV0 => write!(f, "mainnet"),
+            NetworkName::CanaryV0 => write!(f, "canary"),
         }
     }
 }

--- a/utils/retriever/src/program_context/network_name.rs
+++ b/utils/retriever/src/program_context/network_name.rs
@@ -48,6 +48,19 @@ impl TryFrom<&str> for NetworkName {
         }
     }
 }
+impl TryFrom<String> for NetworkName {
+    type Error = LeoError;
+
+    fn try_from(network: String) -> Result<Self, LeoError> {
+        if network == "testnet" {
+            Ok(NetworkName::TestnetV0)
+        } else if network == "mainnet" {
+            Ok(NetworkName::MainnetV0)
+        } else {
+            Err(LeoError::CliError(CliError::invalid_network_name(&network)))
+        }
+    }
+}
 
 impl fmt::Display for NetworkName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
- Features:
	- Deployment variable and constraint limit now enforced in `leo deploy`.
	- Easier interaction with CLI by enabling default usage of network in `.env`.
	- Closes #28082: Adds support for canary network.
	- Changed base to latest commit on `mainnet-staging`  (`AleoNet`).
- Open questions:
	- How should we implement `snarkVM` errors?
	- What is the best advice to give for reducing constraints and variables?