### PR TITLE
[Fix] remove duplicate .aleo when deploying programs

### DIFF
--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -190,7 +190,7 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
         if !command.fee_options.dry_run {
             if !command.fee_options.yes {
                 let prompt = format!(
-                    "Do you want to submit deployment of program `{name}.aleo` to network {} via endpoint {} using address {}?",
+                    "Do you want to submit deployment of program `{name}` to network {} via endpoint {} using address {}?",
                     network, endpoint, address
                 );
                 let confirmation =


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

There is a duplicate ".aleo" present on the confirmation text during program deployment. This pr removes the duplicate ".aleo"

i.e. 

```
? Do you want to submit deployment of program `puzzle_arc_38.aleo.aleo` to network testnet via endpoint https://testnet.puzzle.online
```

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

I built leo locally and tested deploying a program.
