### PR TITLE
fix: update comment to clarify the account is stored as a hash

### DIFF
--- a/examples/basic_bank/src/main.leo
+++ b/examples/basic_bank/src/main.leo
@@ -8,7 +8,7 @@ program basic_bank.aleo {
     }
 
     // An on-chain mapping, storing the amount of tokens owned by each account
-    // The account is stored as a to preserve user privacy.
+    // The account is stored as a hash to preserve user privacy.
     mapping balances: field => u64;
 
     // Returns a new Token.


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

There is a typo in the comment for the basic_bank example.
