### PR TITLE
allow non-leo files to be in src folder

### DIFF
--- a/leo/package/src/lib.rs
+++ b/leo/package/src/lib.rs
@@ -44,19 +44,13 @@ pub(crate) fn parse_file_paths(directory: ReadDir, file_paths: &mut Vec<PathBuf>
             parse_file_paths(directory, file_paths)?;
             continue;
         } else {
-            // Verify that the file has the Leo file extension
-            let file_extension = file_path
-                .extension()
-                .ok_or_else(|| PackageError::failed_to_get_leo_file_extension(file_path.as_os_str().to_owned()))?;
-            if file_extension != LEO_FILE_EXTENSION.trim_start_matches('.') {
-                return Err(PackageError::invalid_leo_file_extension(
-                    file_path.as_os_str().to_owned(),
-                    file_extension.to_owned(),
-                )
-                .into());
+            // If the extension doesn't match, we simply skip this file
+            // If there's no extension, we also skip this file
+            if let Some(file_extension) = file_path.extension() {
+                if file_extension == LEO_FILE_EXTENSION.trim_start_matches('.') {
+                    file_paths.push(file_path);
+                }
             }
-
-            file_paths.push(file_path);
         }
     }
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

I use macOS X, and when I try to copy a file from inside the '**src**' folder or simply visit the folder, macOS X creates '**.DS_Store**' files. When those files are created, Leo suddenly stops building. This is confusing for both newcomers and experienced programmers (it happened to me when my project suddenly stopped building for no apparent reason; the reason was macOS X creating a '**.DS_Store**' file inside the 'src' folder).



## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

put any non leo file inside the src folder.
