### PR TITLE
small error formatting improvements

### DIFF
--- a/compiler/ast/src/types/type_.rs
+++ b/compiler/ast/src/types/type_.rs
@@ -184,7 +184,7 @@ impl fmt::Display for Type {
         match *self {
             Type::Address => write!(f, "address"),
             Type::Array(ref array_type) => write!(f, "{array_type}"),
-            Type::Boolean => write!(f, "boolean"),
+            Type::Boolean => write!(f, "bool"),
             Type::Field => write!(f, "field"),
             Type::Future(ref future_type) => write!(f, "{future_type}"),
             Type::Group => write!(f, "group"),

--- a/compiler/ast/src/types/type_.rs
+++ b/compiler/ast/src/types/type_.rs
@@ -184,7 +184,7 @@ impl fmt::Display for Type {
         match *self {
             Type::Address => write!(f, "address"),
             Type::Array(ref array_type) => write!(f, "{array_type}"),
-            Type::Boolean => write!(f, "bool"),
+            Type::Boolean => write!(f, "boolean"),
             Type::Field => write!(f, "field"),
             Type::Future(ref future_type) => write!(f, "{future_type}"),
             Type::Group => write!(f, "group"),

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -208,7 +208,7 @@ create_messages!(
     invalid_struct_variable {
         args: (variable: impl Display, struct_: impl Display),
         msg: format!(
-            "Variable {variable} is not a member of struct {struct_}."
+            "Variable {variable} is not a member of {struct_}."
         ),
         help: None,
     }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Consider this program:
```
// The 'leo_errors' program.
program leo_errors.aleo {

    struct VoteAggregate {
        proposal_id: field;
        proposal_some: field;
    }

    struct SomeStruct {
        proposal_id: boolean;
    }

    transition main() -> field {
        let st:VoteAggregate = VoteAggregate{
            proposal_id: 0field,
            proposal_some: 0field,
        };

        let ss:SomeStruct = SomeStruct{
            proposal_id: true,
            
        };

        return st.proposal_something;
        
    }
}
```
The output of this program is:

<img width="1082" alt="errors_typos" src="https://github.com/user-attachments/assets/ab41838d-0579-4cf8-9860-bb9dc358317b">

After this PR :

<img width="1096" alt="errors_corrected" src="https://github.com/user-attachments/assets/dc1f055c-c80a-4cf4-b392-3a5278651115">


## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Run the program above.
