### PR TITLE
leo error reporting after build

### DIFF
--- a/compiler/passes/src/type_checking/mod.rs
+++ b/compiler/passes/src/type_checking/mod.rs
@@ -70,7 +70,7 @@ impl<'a, N: Network> Pass for TypeChecker<'a, N> {
         // show warning counts
         if warn_count > 0 {
             println!(
-                "{}warning{}: {}.leo  generated {} warning{}",
+                "{}warning{}: {}.leo generated {} warning{}",
                 YELLOW,
                 RESET,
                 program_name,

--- a/errors/src/emitter/mod.rs
+++ b/errors/src/emitter/mod.rs
@@ -136,11 +136,11 @@ impl Emitter for BufferEmitter {
 
 /// Contains the actual data for `Handler`.
 /// Modelled this way to afford an API using interior mutability.
-struct HandlerInner {
+pub struct HandlerInner {
     /// Number of errors emitted thus far.
-    err_count: usize,
+    pub err_count: usize,
     /// Number of warnings emitted thus far.
-    warn_count: usize,
+    pub warn_count: usize,
     /// The sink through which errors will be emitted.
     emitter: Box<dyn Emitter>,
 }
@@ -168,7 +168,7 @@ impl HandlerInner {
 pub struct Handler {
     /// The inner handler.
     /// `RefCell` is used here to avoid `&mut` all over the compiler.
-    inner: RefCell<HandlerInner>,
+    pub inner: RefCell<HandlerInner>,
 }
 
 impl Default for Handler {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

When developing complex Leo programs, it's not uncommon to encounter multiple compilation errors. This feature, inspired by Rust's error reporting system, provides developers with a clear overview of the number of errors and warnings in their code. Having a precise count of issues serves as a motivational tool, allowing developers to track their progress as they address and resolve bugs. The satisfaction of seeing the error count decrease provides positive reinforcement throughout the debugging process, ultimately enhancing the overall development experience and potentially improving code quality.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Run a leo program that generates errors and warnings.

Here is an example of what it looks like:
<img width="752" alt="leo_error_reporting" src="https://github.com/user-attachments/assets/c1408cd0-5c48-414d-bd53-5bdfcf3addac">

