### PR TITLE
[Feature] Add deployment summary with comma-formatted variables and constraints counts.

### DIFF
--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -122,19 +122,22 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
         // Generate the deployment
         let deployment = package.deploy::<A>(None)?;
 
+        let variables = deployment.num_combined_variables()?;
+        let constraints = deployment.num_combined_constraints()?;
+
         // Check if the number of variables and constraints are within the limits.
-        if deployment.num_combined_variables()? > N::MAX_DEPLOYMENT_VARIABLES {
+        if variables > N::MAX_DEPLOYMENT_VARIABLES {
             return Err(CliError::variable_limit_exceeded(name, N::MAX_DEPLOYMENT_VARIABLES, network).into());
         }
-        if deployment.num_combined_constraints()? > N::MAX_DEPLOYMENT_CONSTRAINTS {
+        if constraints > N::MAX_DEPLOYMENT_CONSTRAINTS {
             return Err(CliError::constraint_limit_exceeded(name, N::MAX_DEPLOYMENT_CONSTRAINTS, network).into());
         }
 
-        // Print deployment summary with comma-formatted variables and constraints counts.
+        // Print deployment summary
         println!(
             "📊 Deployment Summary:\n      Total Variables:   {:>10}\n      Total Constraints: {:>10}",
-            deployment.num_combined_variables()?.to_formatted_string(&Locale::en),
-            deployment.num_combined_constraints()?.to_formatted_string(&Locale::en)
+            variables.to_formatted_string(&Locale::en),
+            constraints.to_formatted_string(&Locale::en)
         );
 
         let deployment_id = deployment.to_deployment_id()?;

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -18,6 +18,7 @@ use super::*;
 use aleo_std::StorageMode;
 use dialoguer::{theme::ColorfulTheme, Confirm};
 use leo_retriever::NetworkName;
+use num_format::{Locale, ToFormattedString};
 use snarkvm::{
     circuit::{Aleo, AleoCanaryV0, AleoTestnetV0, AleoV0},
     ledger::query::Query as SnarkVMQuery,
@@ -128,6 +129,13 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
         if deployment.num_combined_constraints()? > N::MAX_DEPLOYMENT_CONSTRAINTS {
             return Err(CliError::constraint_limit_exceeded(name, N::MAX_DEPLOYMENT_CONSTRAINTS, network).into());
         }
+
+        // Print deployment summary with comma-formatted variables and constraints counts.
+        println!(
+            "📊 Deployment Summary:\n      Total Variables:   {:>10}\n      Total Constraints: {:>10}",
+            deployment.num_combined_variables()?.to_formatted_string(&Locale::en),
+            deployment.num_combined_constraints()?.to_formatted_string(&Locale::en)
+        );
 
         let deployment_id = deployment.to_deployment_id()?;
 


### PR DESCRIPTION

<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Added deployment summary to 'leo deploy' command output.
Displays total variables and constraints with proper formatting.
Improves user visibility into program complexity during deployment.

Looks like this: 
<img width="642" alt="Screenshot 2024-08-26 at 8 24 14 PM" src="https://github.com/user-attachments/assets/905a1871-411a-4cbc-b94e-374fbe9c9932">

