### PR TITLE
[Feature] Leo CLI new version update notification

### DIFF
--- a/leo/cli/helpers/updater.rs
+++ b/leo/cli/helpers/updater.rs
@@ -153,8 +153,17 @@ impl Updater {
                 }
             }
         } else {
-            // We're not checking for updates, so just return whether we have a stored version
-            Ok(version_file.exists())
+            if version_file.exists() {
+                if let Ok(stored_version) = fs::read_to_string(&version_file) {
+                    let current_version = env!("CARGO_PKG_VERSION");
+                    Ok(bump_is_greater(current_version, &stored_version.trim()).map_err(CliError::self_update_error)?)
+                } else {
+                    // If we can't read the file, assume no update is available
+                    Ok(false)
+                }
+            } else {
+                Ok(false)
+            }
         }
     }
 

--- a/leo/cli/helpers/updater.rs
+++ b/leo/cli/helpers/updater.rs
@@ -152,18 +152,16 @@ impl Updater {
                     Ok(false)
                 }
             }
-        } else {
-            if version_file.exists() {
-                if let Ok(stored_version) = fs::read_to_string(&version_file) {
-                    let current_version = env!("CARGO_PKG_VERSION");
-                    Ok(bump_is_greater(current_version, &stored_version.trim()).map_err(CliError::self_update_error)?)
-                } else {
-                    // If we can't read the file, assume no update is available
-                    Ok(false)
-                }
+        } else if version_file.exists() {
+            if let Ok(stored_version) = fs::read_to_string(&version_file) {
+                let current_version = env!("CARGO_PKG_VERSION");
+                Ok(bump_is_greater(current_version, stored_version.trim()).map_err(CliError::self_update_error)?)
             } else {
+                // If we can't read the file, assume no update is available
                 Ok(false)
             }
+        } else {
+            Ok(false)
         }
     }
 
@@ -184,7 +182,7 @@ impl Updater {
         let current_time = Self::get_current_time()?;
 
         // Write the current time to the last check file.
-        fs::write(last_check_file, &current_time.to_string()).map_err(CliError::cli_io_error)?;
+        fs::write(last_check_file, current_time.to_string()).map_err(CliError::cli_io_error)?;
 
         // Write the latest version to the version file.
         fs::write(version_file, latest_version).map_err(CliError::cli_io_error)?;

--- a/leo/cli/main.rs
+++ b/leo/cli/main.rs
@@ -18,7 +18,6 @@ use leo_lang::cli::*;
 use leo_span::symbol::create_session_if_not_set_then;
 
 use clap::Parser;
-use std::env;
 
 fn set_panic_hook() {
     #[cfg(not(debug_assertions))]

--- a/leo/cli/main.rs
+++ b/leo/cli/main.rs
@@ -18,6 +18,7 @@ use leo_lang::cli::*;
 use leo_span::symbol::create_session_if_not_set_then;
 
 use clap::Parser;
+use std::env;
 
 fn set_panic_hook() {
     #[cfg(not(debug_assertions))]


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Implemented an update notification system to keep users informed about new versions of the Leo CLI tool. 
This PR introduces the following enhancements to the update notification system:

1. **Conditional Update Checks**: The update notification system performs checks based on a time interval (currently set to once per day) or when forced, reducing unnecessary network requests. It writes the last check timestamp and latest version to cache files. This check runs on any command with arguments.

2. **Integration with Help and Version Commands**: Update notifications are also integrated into the help (`--help`) and version (`--version`) command outputs. These commands do not trigger an update check; instead, they read from the cached latest version file.

Closes #28335 

