### PR TITLE
mod: Refactor Testnet Endpoint frrom api.explorer.aleo.org to api.exp…

### DIFF
--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -22,7 +22,7 @@ use super::*;
 pub struct Deploy {
     #[clap(long, help = "Custom priority fee in microcredits", default_value = "1000000")]
     pub(crate) priority_fee: String,
-    #[clap(long, help = "Custom query endpoint", default_value = "http://api.explorer.aleo.org/v1")]
+    #[clap(long, help = "Custom query endpoint", default_value = "http://api.explorer.provable.com/v1")]
     pub(crate) endpoint: String,
     #[clap(long, help = "Custom network", default_value = "testnet3")]
     pub(crate) network: String,

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -125,7 +125,7 @@ pub struct BuildOptions {
     #[clap(
         long,
         help = "Endpoint to retrieve on-chain dependencies from.",
-        default_value = "http://api.explorer.aleo.org/v1"
+        default_value = "http://api.explorer.provable.com/v1"
     )]
     pub endpoint: String,
     #[clap(long, help = "Does not recursively compile dependencies.")]


### PR DESCRIPTION
Hello developers,

Before this commit:
- When creating new project with `leo new <project_name>`. The default value for ENDPOINT in `.env` file is `https://api.explorer.aleo.org/v1`. This endpoint is Old one,

What this commit solve:
- The default value for ENDPOINT in `.env` file is `https://api.explorer.provable.com/v1` while creating new project.