### PR TITLE
Require comma separators (and nothing else) between struct members.

### DIFF
--- a/compiler/parser/src/parser/file.rs
+++ b/compiler/parser/src/parser/file.rs
@@ -180,23 +180,11 @@ impl<N: Network> ParserContext<'_, N> {
     fn parse_struct_members(&mut self) -> Result<(Vec<Member>, Span)> {
         let mut members = Vec::new();
 
-        let (mut semi_colons, mut commas) = (false, false);
-
         while !self.check(&Token::RightCurly) {
             let variable = self.parse_member_variable_declaration()?;
 
-            if self.eat(&Token::Semicolon) {
-                if commas {
-                    self.emit_err(ParserError::mixed_commas_and_semicolons(self.token.span));
-                }
-                semi_colons = true;
-            }
-
-            if self.eat(&Token::Comma) {
-                if semi_colons {
-                    self.emit_err(ParserError::mixed_commas_and_semicolons(self.token.span));
-                }
-                commas = true;
+            if !self.check(&Token::RightCurly) && !self.eat(&Token::Comma) {
+                self.emit_err(ParserError::comma_expected_after_member(self.token.span));
             }
 
             members.push(variable);

--- a/errors/src/errors/parser/parser_errors.rs
+++ b/errors/src/errors/parser/parser_errors.rs
@@ -73,6 +73,7 @@ create_messages!(
     }
 
     /// For when the parser encountered a mix of commas and semi-colons in struct member variables.
+    // TODO unused
     @formatted
     mixed_commas_and_semicolons {
         args: (),
@@ -339,6 +340,14 @@ create_messages!(
     cannot_define_external_record {
         args: (),
         msg: format!("Cannot create an external record. Records can only be created in the program that they are defined in."),
+        help: None,
+    }
+
+    /// For when the parser encountered a member declaration not followed by a comma.
+    @formatted
+    comma_expected_after_member {
+        args: (),
+        msg: "Each member declaration in a struct or record must be followed by a comma (except the last).",
         help: None,
     }
 );

--- a/tests/expectations/parser/structs/comma_separators_fail.out
+++ b/tests/expectations/parser/structs/comma_separators_fail.out
@@ -1,0 +1,5 @@
+---
+namespace: Parse
+expectation: Fail
+outputs:
+  - "Error [EPAR0370041]: Each member declaration in a struct or record must be followed by a comma (except the last).\n    --> test:5:9\n     |\n   5 |         y: u8\n     |         ^"

--- a/tests/expectations/parser/structs/only_comma_separators_fail.out
+++ b/tests/expectations/parser/structs/only_comma_separators_fail.out
@@ -1,0 +1,5 @@
+---
+namespace: Parse
+expectation: Fail
+outputs:
+  - "Error [EPAR0370041]: Each member declaration in a struct or record must be followed by a comma (except the last).\n    --> test:4:14\n     |\n   4 |         x: u8;\n     |              ^\nError [EPAR0370009]: unexpected string: expected 'identifier', found ';'\n    --> test:4:14\n     |\n   4 |         x: u8;\n     |              ^"

--- a/tests/tests/compiler/bugs/unknown_variable_fail.leo
+++ b/tests/tests/compiler/bugs/unknown_variable_fail.leo
@@ -11,7 +11,7 @@ program test.aleo {
         decimals: u8,
         circulating_supply: u64,
         total_supply: u64,
-        testers: u64
+        testers: u64,
         admin: address,
     }
 

--- a/tests/tests/compiler/console/assert.leo
+++ b/tests/tests/compiler/console/assert.leo
@@ -5,7 +5,7 @@ expectation: Pass
 
 program test.aleo {    
     struct Foo {
-        a: u8;
+        a: u8,
     }
     
     record Token {

--- a/tests/tests/compiler/expression/cast_fail.leo
+++ b/tests/tests/compiler/expression/cast_fail.leo
@@ -8,7 +8,7 @@ program test.aleo {
     mapping balances: field => field;
 
     struct Foo {
-        data: field;
+        data: field,
     }
 
     async transition main(a: field) -> Future {

--- a/tests/tests/compiler/finalize/mapping.leo
+++ b/tests/tests/compiler/finalize/mapping.leo
@@ -11,18 +11,18 @@ program test.aleo {
     mapping balances: address => u128;
     
     struct Token {
-        Owner: address;
-        balance: u128;
+        Owner: address,
+        balance: u128,
     }
     
     mapping tokens: address => Token;
     
     struct Bar {
-        a: u128;
+        a: u128,
     }
     
     struct Baz {
-        a: u128;
+        a: u128,
     }
     
     mapping foo: Bar => Baz;

--- a/tests/tests/compiler/finalize/shadow_mapping_fail.leo
+++ b/tests/tests/compiler/finalize/shadow_mapping_fail.leo
@@ -21,6 +21,6 @@ program test.aleo {
     }
     
     struct bar {
-        a: u64;
+        a: u64,
     }
 }

--- a/tests/tests/compiler/mappings/read_external_mapping.leo
+++ b/tests/tests/compiler/mappings/read_external_mapping.leo
@@ -27,8 +27,8 @@ program relay.aleo {
     mapping users: address => bool;
 
     record message {
-        owner: address;
-        data: u8;
+        owner: address,
+        data: u8,
     }
 
     async transition send(addr: address, val: u8) -> (message, Future) {

--- a/tests/tests/compiler/structs/inline_fail.leo
+++ b/tests/tests/compiler/structs/inline_fail.leo
@@ -5,7 +5,7 @@ expectation: Fail
 
 program test.aleo {    
     struct Foo {
-        x: u32;
+        x: u32,
     }
     
     function main() {

--- a/tests/tests/compiler/structs/inline_member_fail.leo
+++ b/tests/tests/compiler/structs/inline_member_fail.leo
@@ -5,7 +5,7 @@ expectation: Fail
 
 program test.aleo {    
     struct Foo {
-        x: u8;
+        x: u8,
     }
     
     function main() {

--- a/tests/tests/compiler/structs/member_variable_fail.leo
+++ b/tests/tests/compiler/structs/member_variable_fail.leo
@@ -5,7 +5,7 @@ expectation: Fail
 
 program test.aleo {    
     struct Foo {
-        x: u32;
+        x: u32,
     }
     
     function main() {

--- a/tests/tests/compiler/structs/struct_function_namespace_conflict_fail.leo
+++ b/tests/tests/compiler/structs/struct_function_namespace_conflict_fail.leo
@@ -5,7 +5,7 @@ expectation: Fail
 
 program test.aleo {    
     struct Foo {
-        x: u8;
+        x: u8,
     }
     
     function Foo() {}

--- a/tests/tests/parser/structs/comma_separators_fail.leo
+++ b/tests/tests/parser/structs/comma_separators_fail.leo
@@ -1,0 +1,14 @@
+/*
+namespace: Parse
+expectation: Fail
+*/
+program comma_separators.aleo {
+    struct none {
+        x: u8
+        y: u8
+    }
+
+    transition main(public a: u32) -> u32 {
+		return a;
+    }
+}

--- a/tests/tests/parser/structs/only_comma_separators_fail.leo
+++ b/tests/tests/parser/structs/only_comma_separators_fail.leo
@@ -1,0 +1,19 @@
+/*
+namespace: Parse
+expectation: Fail
+*/
+program only_comma_separators.aleo {
+    struct semicolons {
+        x: u8;
+        y: u8
+    }
+
+    struct semicolons_with_trailing {
+        x: u8;
+        y: u8;
+    }
+
+    transition main(public a: u32) -> u32 {
+		return a;
+    }
+}


### PR DESCRIPTION
Fixes #28377, #28379
