### PR TITLE
Turn off LTO for dev and test builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,12 +242,12 @@ debug-assertions = false
 
 [profile.dev]
 opt-level = 2
-lto = "thin"
+lto = "off"
 incremental = true
 
 [profile.test]
 opt-level = 2
-lto = "thin"
+lto = "off"
 incremental = true
 debug = true
 debug-assertions = true


### PR DESCRIPTION
This results in a penalty to full compilation time, but a dramatic speedup to partial recompilation time.