### PR TITLE
Fixes to clap CLI code.

### DIFF
--- a/leo/cli/cli.rs
+++ b/leo/cli/cli.rs
@@ -50,7 +50,7 @@ enum Commands {
     #[clap(about = "Create a new Leo package in a new directory")]
     New {
         #[clap(flatten)]
-        command: New,
+        command: LeoNew,
     },
     #[clap(about = "Create a new Leo example package in a new directory")]
     Example {
@@ -60,12 +60,12 @@ enum Commands {
     #[clap(about = "Run a program with input variables")]
     Run {
         #[clap(flatten)]
-        command: Run,
+        command: LeoRun,
     },
     #[clap(about = "Execute a program with input variables")]
     Execute {
         #[clap(flatten)]
-        command: Execute,
+        command: LeoExecute,
     },
     #[clap(about = "Deploy a program")]
     Deploy {
@@ -75,32 +75,32 @@ enum Commands {
     #[clap(about = "Query live data from the Aleo network")]
     Query {
         #[clap(flatten)]
-        command: Query,
+        command: LeoQuery,
     },
     #[clap(about = "Compile the current package as a program")]
     Build {
         #[clap(flatten)]
-        command: Build,
+        command: LeoBuild,
     },
     #[clap(about = "Add a new on-chain or local dependency to the current package.")]
     Add {
         #[clap(flatten)]
-        command: Add,
+        command: LeoAdd,
     },
     #[clap(about = "Remove a dependency from the current package.")]
     Remove {
         #[clap(flatten)]
-        command: Remove,
+        command: LeoRemove,
     },
     #[clap(about = "Clean the output directory")]
     Clean {
         #[clap(flatten)]
-        command: Clean,
+        command: LeoClean,
     },
     #[clap(about = "Update the Leo CLI")]
     Update {
         #[clap(flatten)]
-        command: Update,
+        command: LeoUpdate,
     },
 }
 
@@ -169,7 +169,7 @@ mod tests {
             debug: false,
             quiet: false,
             command: Commands::Run {
-                command: crate::cli::commands::Run {
+                command: crate::cli::commands::LeoRun {
                     name: "example".to_string(),
                     inputs: vec!["1u32".to_string(), "2u32".to_string()],
                     file: None,
@@ -211,7 +211,7 @@ mod tests {
             debug: false,
             quiet: false,
             command: Commands::Run {
-                command: crate::cli::commands::Run {
+                command: crate::cli::commands::LeoRun {
                     name: "double_wrapper_mint".to_string(),
                     inputs: vec![
                         "aleo13tngrq7506zwdxj0cxjtvp28pk937jejhne0rt4zp0z370uezuysjz2prs".to_string(),
@@ -254,7 +254,7 @@ mod tests {
             debug: false,
             quiet: false,
             command: Commands::Run {
-                command: crate::cli::commands::Run {
+                command: crate::cli::commands::LeoRun {
                     name: "inner_1_main".to_string(),
                     inputs: vec!["1u32".to_string(), "2u32".to_string()],
                     compiler_options: Default::default(),
@@ -291,7 +291,7 @@ mod tests {
             debug: false,
             quiet: false,
             command: Commands::Run {
-                command: crate::cli::commands::Run {
+                command: crate::cli::commands::LeoRun {
                     name: "main".to_string(),
                     inputs: vec!["1u32".to_string(), "2u32".to_string()],
                     compiler_options: Default::default(),
@@ -310,7 +310,7 @@ mod tests {
 
 #[cfg(test)]
 mod test_helpers {
-    use crate::cli::{Add, CLI, New, cli::Commands, run_with_args};
+    use crate::cli::{CLI, LeoAdd, LeoNew, cli::Commands, run_with_args};
     use leo_span::symbol::create_session_if_not_set_then;
     use std::path::Path;
 
@@ -331,7 +331,11 @@ mod test_helpers {
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New { name: name.to_string(), network: NETWORK.to_string(), endpoint: ENDPOINT.to_string() },
+                command: LeoNew {
+                    name: name.to_string(),
+                    network: NETWORK.to_string(),
+                    endpoint: ENDPOINT.to_string(),
+                },
             },
             path: Some(project_directory.clone()),
             home: None,
@@ -397,7 +401,7 @@ function external_nested_function:
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "nested_example_layer_0".to_string(),
                     local: None,
                     network: NETWORK.to_string(),
@@ -434,7 +438,7 @@ function external_nested_function:
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "grandparent".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -448,7 +452,7 @@ function external_nested_function:
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "parent".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -462,7 +466,7 @@ function external_nested_function:
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "child".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -509,7 +513,7 @@ program child.aleo {
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "parent".to_string(),
                     local: Some(parent_directory.clone()),
                     network: NETWORK.to_string(),
@@ -524,7 +528,7 @@ program child.aleo {
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "child".to_string(),
                     local: Some(child_directory.clone()),
                     network: NETWORK.to_string(),
@@ -539,7 +543,7 @@ program child.aleo {
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "child".to_string(),
                     local: Some(child_directory.clone()),
                     network: NETWORK.to_string(),
@@ -583,7 +587,7 @@ program child.aleo {
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "outer".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -597,7 +601,7 @@ program child.aleo {
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "inner_1".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -611,7 +615,7 @@ program child.aleo {
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "inner_2".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -681,7 +685,7 @@ program outer.aleo {
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "inner_1".to_string(),
                     local: Some(inner_1_directory.clone()),
                     network: NETWORK.to_string(),
@@ -696,7 +700,7 @@ program outer.aleo {
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "inner_2".to_string(),
                     local: Some(inner_2_directory.clone()),
                     network: NETWORK.to_string(),
@@ -739,7 +743,7 @@ program outer.aleo {
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "outer_2".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -753,7 +757,7 @@ program outer.aleo {
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "inner_1".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -767,7 +771,7 @@ program outer.aleo {
             debug: false,
             quiet: false,
             command: Commands::New {
-                command: New {
+                command: LeoNew {
                     name: "inner_2".to_string(),
                     network: NETWORK.to_string(),
                     endpoint: ENDPOINT.to_string(),
@@ -868,7 +872,7 @@ program outer_2.aleo {
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "inner_1".to_string(),
                     local: Some(inner_1_directory.clone()),
                     network: NETWORK.to_string(),
@@ -883,7 +887,7 @@ program outer_2.aleo {
             debug: false,
             quiet: false,
             command: Commands::Add {
-                command: Add {
+                command: LeoAdd {
                     name: "inner_2".to_string(),
                     local: Some(inner_2_directory.clone()),
                     network: NETWORK.to_string(),

--- a/leo/cli/commands/add.rs
+++ b/leo/cli/commands/add.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 /// Add a new on-chain or local dependency to the current package.
 #[derive(Parser, Debug)]
 #[clap(name = "leo", author = "The Leo Team <leo@provable.com>", version)]
-pub struct Add {
+pub struct LeoAdd {
     #[clap(name = "NAME", help = "The dependency name. Ex: `credits.aleo` or `credits`.")]
     pub(crate) name: String,
 
@@ -35,7 +35,7 @@ pub struct Add {
     pub(crate) clear: bool,
 }
 
-impl Command for Add {
+impl Command for LeoAdd {
     type Input = ();
     type Output = ();
 

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -75,12 +75,12 @@ impl From<BuildOptions> for CompilerOptions {
 
 /// Compile and build program command.
 #[derive(Parser, Debug)]
-pub struct Build {
+pub struct LeoBuild {
     #[clap(flatten)]
     pub(crate) options: BuildOptions,
 }
 
-impl Command for Build {
+impl Command for LeoBuild {
     type Input = ();
     type Output = ();
 
@@ -104,7 +104,7 @@ impl Command for Build {
 }
 
 // A helper function to handle the build command.
-fn handle_build<N: Network>(command: &Build, context: Context) -> Result<<Build as Command>::Output> {
+fn handle_build<N: Network>(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Command>::Output> {
     // Get the package path.
     let package_path = context.dir()?;
     let home_path = context.home()?;

--- a/leo/cli/commands/clean.rs
+++ b/leo/cli/commands/clean.rs
@@ -18,9 +18,9 @@ use super::*;
 
 /// Clean outputs folder command
 #[derive(Parser, Debug)]
-pub struct Clean {}
+pub struct LeoClean {}
 
-impl Command for Clean {
+impl Command for LeoClean {
     type Input = ();
     type Output = ();
 

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -68,7 +68,7 @@ impl Command for Deploy {
 
     fn prelude(&self, context: Context) -> Result<Self::Input> {
         if !self.no_build {
-            (Build { options: self.options.clone() }).execute(context)?;
+            (LeoBuild { options: self.options.clone() }).execute(context)?;
         }
         Ok(())
     }

--- a/leo/cli/commands/example.rs
+++ b/leo/cli/commands/example.rs
@@ -35,12 +35,12 @@ pub struct Example {
 }
 
 impl Command for Example {
-    type Input = <New as Command>::Output;
+    type Input = <LeoNew as Command>::Output;
     type Output = ();
 
     fn prelude(&self, context: Context) -> Result<Self::Input> {
         // Run leo new <name> --network <network>
-        (New { name: self.name.clone(), network: self.network.clone(), endpoint: self.endpoint.clone() })
+        (LeoNew { name: self.name.clone(), network: self.network.clone(), endpoint: self.endpoint.clone() })
             .execute(context)
     }
 

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -52,7 +52,7 @@ use snarkvm::{
 
 /// Build, Prove and Run Leo program with inputs
 #[derive(Parser, Debug)]
-pub struct Execute {
+pub struct LeoExecute {
     #[clap(name = "NAME", help = "The name of the function to execute.", default_value = "main")]
     name: String,
     #[clap(name = "INPUTS", help = "The inputs to the program.")]
@@ -73,8 +73,8 @@ pub struct Execute {
     pub(crate) no_build: bool,
 }
 
-impl Command for Execute {
-    type Input = <Build as Command>::Output;
+impl Command for LeoExecute {
+    type Input = <LeoBuild as Command>::Output;
     type Output = ();
 
     fn log_span(&self) -> Span {
@@ -86,7 +86,7 @@ impl Command for Execute {
         if self.program.is_some() || self.no_build {
             return Ok(());
         }
-        (Build { options: self.compiler_options.clone() }).execute(context)
+        (LeoBuild { options: self.compiler_options.clone() }).execute(context)
     }
 
     fn apply(self, context: Context, _input: Self::Input) -> Result<Self::Output> {
@@ -113,11 +113,11 @@ impl Command for Execute {
 
 // A helper function to handle the `execute` command.
 fn handle_execute<A: Aleo>(
-    command: Execute,
+    command: LeoExecute,
     context: Context,
     network: NetworkName,
     endpoint: &str,
-) -> Result<<Execute as Command>::Output> {
+) -> Result<<LeoExecute as Command>::Output> {
     // If input values are provided, then run the program with those inputs.
     // Otherwise, use the input file.
     let mut inputs = command.inputs.clone();
@@ -361,11 +361,11 @@ fn load_program_from_network<N: Network>(
     endpoint: &str,
 ) -> Result<()> {
     // Fetch the program.
-    let program_src = Query {
+    let program_src = LeoQuery {
         endpoint: Some(endpoint.to_string()),
         network: Some(network.to_string()),
         command: QueryCommands::Program {
-            command: query::Program { name: program_id.to_string(), mappings: false, mapping_value: None },
+            command: query::LeoProgram { name: program_id.to_string(), mappings: false, mapping_value: None },
         },
     }
     .execute(Context::new(context.path.clone(), context.home.clone(), true)?)?;

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -15,16 +15,16 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod add;
-pub use add::Add;
+pub use add::LeoAdd;
 
 pub mod account;
 pub use account::Account;
 
 pub mod build;
-pub use build::Build;
+pub use build::LeoBuild;
 
 pub mod clean;
-pub use clean::Clean;
+pub use clean::LeoClean;
 
 pub mod deploy;
 pub use deploy::Deploy;
@@ -33,25 +33,25 @@ pub mod example;
 pub use example::Example;
 
 pub mod execute;
-pub use execute::Execute;
+pub use execute::LeoExecute;
 
 pub mod query;
-pub use query::Query;
+pub use query::LeoQuery;
 
 pub mod new;
-pub use new::New;
+pub use new::LeoNew;
 
 // pub mod node;
 // pub use node::Node;
 
 pub mod remove;
-pub use remove::Remove;
+pub use remove::LeoRemove;
 
 pub mod run;
-pub use run::Run;
+pub use run::LeoRun;
 
 pub mod update;
-pub use update::Update;
+pub use update::LeoUpdate;
 
 use super::*;
 use crate::cli::helpers::context::*;
@@ -247,11 +247,11 @@ fn check_balance<N: Network>(
     // Derive the account address.
     let address = Address::<N>::try_from(ViewKey::try_from(private_key)?)?;
     // Query the public balance of the address on the `account` mapping from `credits.aleo`.
-    let mut public_balance = Query {
+    let mut public_balance = LeoQuery {
         endpoint: Some(endpoint.to_string()),
         network: Some(network.to_string()),
         command: QueryCommands::Program {
-            command: crate::cli::commands::query::Program {
+            command: crate::cli::commands::query::LeoProgram {
                 name: "credits".to_string(),
                 mappings: false,
                 mapping_value: Some(vec!["account".to_string(), address.to_string()]),

--- a/leo/cli/commands/new.rs
+++ b/leo/cli/commands/new.rs
@@ -21,7 +21,7 @@ use leo_retriever::NetworkName;
 
 /// Create new Leo project
 #[derive(Parser, Debug)]
-pub struct New {
+pub struct LeoNew {
     #[clap(name = "NAME", help = "Set package name")]
     pub(crate) name: String,
     #[clap(short = 'n', long, help = "Name of the network to use", default_value = "testnet")]
@@ -35,7 +35,7 @@ pub struct New {
     pub(crate) endpoint: String,
 }
 
-impl Command for New {
+impl Command for LeoNew {
     type Input = ();
     type Output = ();
 

--- a/leo/cli/commands/query/block.rs
+++ b/leo/cli/commands/query/block.rs
@@ -21,14 +21,14 @@ use clap::Parser;
 
 // Query on-chain information related to blocks.
 #[derive(Parser, Debug)]
-pub struct Block {
+pub struct LeoBlock {
     #[clap(help = "Fetch a block by specifying its height or hash", required_unless_present_any = &["latest", "latest_hash", "latest_height", "range"])]
     pub(crate) id: Option<String>,
     #[arg(short, long, help = "Get the latest block", default_value = "false", conflicts_with_all(["latest_hash", "latest_height", "range", "transactions", "to_height"]))]
     pub(crate) latest: bool,
-    #[arg(short, long, help = "Get the latest block hash", default_value = "false", conflicts_with_all(["latest", "latest_height", "range", "transactions", "to_height"]))]
+    #[arg(long, help = "Get the latest block hash", default_value = "false", conflicts_with_all(["latest", "latest_height", "range", "transactions", "to_height"]))]
     pub(crate) latest_hash: bool,
-    #[arg(short, long, help = "Get the latest block height", default_value = "false", conflicts_with_all(["latest", "latest_hash", "range", "transactions", "to_height"]))]
+    #[arg(long, help = "Get the latest block height", default_value = "false", conflicts_with_all(["latest", "latest_hash", "range", "transactions", "to_height"]))]
     pub(crate) latest_height: bool,
     #[arg(short, long, help = "Get up to 50 consecutive blocks", number_of_values = 2, value_names = &["START_HEIGHT", "END_HEIGHT"], conflicts_with_all(["latest", "latest_hash", "latest_height", "transactions", "to_height"]))]
     pub(crate) range: Option<Vec<String>>,
@@ -40,11 +40,11 @@ pub struct Block {
         default_value = "false"
     )]
     pub(crate) transactions: bool,
-    #[arg(short, long, help = "Lookup the block height corresponding to a hash value", default_value = "false")]
+    #[arg(long, help = "Lookup the block height corresponding to a hash value", default_value = "false")]
     pub(crate) to_height: bool,
 }
 
-impl Command for Block {
+impl Command for LeoBlock {
     type Input = ();
     type Output = String;
 

--- a/leo/cli/commands/query/committee.rs
+++ b/leo/cli/commands/query/committee.rs
@@ -20,9 +20,9 @@ use clap::Parser;
 
 /// Query the committee.
 #[derive(Parser, Debug)]
-pub struct Committee {}
+pub struct LeoCommittee {}
 
-impl Command for Committee {
+impl Command for LeoCommittee {
     type Input = ();
     type Output = String;
 

--- a/leo/cli/commands/query/mempool.rs
+++ b/leo/cli/commands/query/mempool.rs
@@ -21,9 +21,8 @@ use clap::Parser;
 
 // Query transactions and transmissions from the memory pool.
 #[derive(Parser, Debug)]
-pub struct Mempool {
+pub struct LeoMempool {
     #[arg(
-        short,
         long,
         help = "Get the memory pool transactions",
         default_value = "false",
@@ -32,7 +31,6 @@ pub struct Mempool {
     )]
     pub(crate) transactions: bool,
     #[arg(
-        short,
         long,
         help = "Get the memory pool transmissions",
         default_value = "false",
@@ -42,7 +40,7 @@ pub struct Mempool {
     pub(crate) transmissions: bool,
 }
 
-impl Command for Mempool {
+impl Command for LeoMempool {
     type Input = ();
     type Output = String;
 

--- a/leo/cli/commands/query/mod.rs
+++ b/leo/cli/commands/query/mod.rs
@@ -18,25 +18,25 @@ use super::*;
 use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 
 mod block;
-use block::Block;
+use block::LeoBlock;
 
 pub mod program;
-pub use program::Program;
+pub use program::LeoProgram;
 
 mod state_root;
 use state_root::StateRoot;
 
 mod committee;
-use committee::Committee;
+use committee::LeoCommittee;
 
 mod mempool;
-use mempool::Mempool;
+use mempool::LeoMempool;
 
 mod peers;
-use peers::Peers;
+use peers::LeoPeers;
 
 mod transaction;
-use transaction::Transaction;
+use transaction::LeoTransaction;
 
 mod utils;
 use utils::*;
@@ -46,7 +46,7 @@ use leo_retriever::{NetworkName, fetch_from_network, verify_valid_program};
 
 ///  Query live data from the Aleo network.
 #[derive(Parser, Debug)]
-pub struct Query {
+pub struct LeoQuery {
     #[clap(short, long, global = true, help = "Endpoint to retrieve network state from. Defaults to entry in `.env`.")]
     pub endpoint: Option<String>,
     #[clap(short, long, global = true, help = "Network to use. Defaults to entry in `.env`.")]
@@ -55,7 +55,7 @@ pub struct Query {
     pub command: QueryCommands,
 }
 
-impl Command for Query {
+impl Command for LeoQuery {
     type Input = ();
     type Output = String;
 
@@ -81,11 +81,11 @@ impl Command for Query {
 
 // A helper function to handle the `query` command.
 fn handle_query<N: Network>(
-    query: Query,
+    query: LeoQuery,
     context: Context,
     network: &str,
     endpoint: &str,
-) -> Result<<Query as Command>::Output> {
+) -> Result<<LeoQuery as Command>::Output> {
     let recursive = context.recursive;
     let (program, output) = match query.command {
         QueryCommands::Block { command } => (None, command.apply(context, ())?),
@@ -137,17 +137,17 @@ pub enum QueryCommands {
     #[clap(about = "Query block information")]
     Block {
         #[clap(flatten)]
-        command: Block,
+        command: LeoBlock,
     },
     #[clap(about = "Query transaction information")]
     Transaction {
         #[clap(flatten)]
-        command: Transaction,
+        command: LeoTransaction,
     },
     #[clap(about = "Query program source code and live mapping values")]
     Program {
         #[clap(flatten)]
-        command: Program,
+        command: LeoProgram,
     },
     #[clap(about = "Query the latest stateroot")]
     Stateroot {
@@ -157,16 +157,16 @@ pub enum QueryCommands {
     #[clap(about = "Query the current committee")]
     Committee {
         #[clap(flatten)]
-        command: Committee,
+        command: LeoCommittee,
     },
     #[clap(about = "Query transactions and transmissions from the memory pool")]
     Mempool {
         #[clap(flatten)]
-        command: Mempool,
+        command: LeoMempool,
     },
     #[clap(about = "Query peer information")]
     Peers {
         #[clap(flatten)]
-        command: Peers,
+        command: LeoPeers,
     },
 }

--- a/leo/cli/commands/query/peers.rs
+++ b/leo/cli/commands/query/peers.rs
@@ -21,7 +21,7 @@ use clap::Parser;
 
 // Query information about network peers.
 #[derive(Parser, Debug)]
-pub struct Peers {
+pub struct LeoPeers {
     #[arg(short, long, help = "Get all peer metrics", default_value = "false", conflicts_with("count"))]
     pub(crate) metrics: bool,
     #[arg(
@@ -34,7 +34,7 @@ pub struct Peers {
     pub(crate) count: bool,
 }
 
-impl Command for Peers {
+impl Command for LeoPeers {
     type Input = ();
     type Output = String;
 

--- a/leo/cli/commands/query/program.rs
+++ b/leo/cli/commands/query/program.rs
@@ -21,22 +21,21 @@ use leo_package::package::Package;
 
 /// Query program source code and live mapping values.
 #[derive(Parser, Debug)]
-pub struct Program {
+pub struct LeoProgram {
     #[clap(name = "NAME", help = "The name of the program to fetch")]
     pub(crate) name: String,
     #[arg(
-        short,
         long,
         help = "Get all mappings defined in the program",
         default_value = "false",
         conflicts_with = "mapping_value"
     )]
     pub(crate) mappings: bool,
-    #[arg(short, long, help = "Get the value corresponding to the specified mapping and key.", number_of_values = 2, value_names = &["MAPPING", "KEY"], conflicts_with = "mappings")]
+    #[arg(long, help = "Get the value corresponding to the specified mapping and key.", number_of_values = 2, value_names = &["MAPPING", "KEY"], conflicts_with = "mappings")]
     pub(crate) mapping_value: Option<Vec<String>>,
 }
 
-impl Command for Program {
+impl Command for LeoProgram {
     type Input = ();
     type Output = String;
 

--- a/leo/cli/commands/query/transaction.rs
+++ b/leo/cli/commands/query/transaction.rs
@@ -20,20 +20,20 @@ use clap::Parser;
 
 /// Query transaction information.
 #[derive(Parser, Debug)]
-pub struct Transaction {
-    #[clap(name = "ID", help = "The id of the transaction to fetch", required_unless_present_any = &["from_program", "from_transition", "from_io", "range"])]
+pub struct LeoTransaction {
+    #[clap(name = "ID", help = "The id of the transaction to fetch", required_unless_present_any = &["from_program", "from_transition", "from_io"])]
     pub(crate) id: Option<String>,
     #[arg(short, long, help = "Get the transaction only if it has been confirmed", default_value = "false", conflicts_with_all(["from_io", "from_transition", "from_program"]))]
     pub(crate) confirmed: bool,
-    #[arg(value_name = "INPUT_OR_OUTPUT_ID", short, long, help = "Get the transition id that an input or output id occurred in", conflicts_with_all(["from_program", "from_transition", "confirmed", "id"]))]
+    #[arg(value_name = "INPUT_OR_OUTPUT_ID", long, help = "Get the transition id that an input or output id occurred in", conflicts_with_all(["from_program", "from_transition", "confirmed"]))]
     pub(crate) from_io: Option<String>,
-    #[arg(value_name = "TRANSITION_ID", short, long, help = "Get the id of the transaction containing the specified transition", conflicts_with_all(["from_io", "from_program", "confirmed", "id"]))]
+    #[arg(value_name = "TRANSITION_ID", long, help = "Get the id of the transaction containing the specified transition", conflicts_with_all(["from_io", "from_program", "confirmed"]))]
     pub(crate) from_transition: Option<String>,
-    #[arg(value_name = "PROGRAM", short, long, help = "Get the id of the transaction id that the specified program was deployed in", conflicts_with_all(["from_io", "from_transition", "confirmed", "id"]))]
+    #[arg(value_name = "PROGRAM", long, help = "Get the id of the transaction id that the specified program was deployed in", conflicts_with_all(["from_io", "from_transition", "confirmed"]))]
     pub(crate) from_program: Option<String>,
 }
 
-impl Command for Transaction {
+impl Command for LeoTransaction {
     type Input = ();
     type Output = String;
 

--- a/leo/cli/commands/remove.rs
+++ b/leo/cli/commands/remove.rs
@@ -20,7 +20,7 @@ use leo_retriever::{Dependency, Manifest};
 /// Remove a dependency from the current package.
 #[derive(Parser, Debug)]
 #[clap(name = "leo", author = "The Leo Team <leo@provable.com>", version)]
-pub struct Remove {
+pub struct LeoRemove {
     #[clap(
         name = "NAME",
         help = "The dependency name. Ex: `credits.aleo` or `credits`.",
@@ -32,7 +32,7 @@ pub struct Remove {
     pub(crate) all: bool,
 }
 
-impl Command for Remove {
+impl Command for LeoRemove {
     type Input = ();
     type Output = ();
 

--- a/leo/cli/commands/run.rs
+++ b/leo/cli/commands/run.rs
@@ -24,7 +24,7 @@ use snarkvm::{
 
 /// Build, Prove and Run Leo program with inputs
 #[derive(Parser, Debug)]
-pub struct Run {
+pub struct LeoRun {
     #[clap(name = "NAME", help = "The name of the program to run.", default_value = "main")]
     pub(crate) name: String,
 
@@ -38,8 +38,8 @@ pub struct Run {
     pub(crate) compiler_options: BuildOptions,
 }
 
-impl Command for Run {
-    type Input = <Build as Command>::Output;
+impl Command for LeoRun {
+    type Input = <LeoBuild as Command>::Output;
     type Output = ();
 
     fn log_span(&self) -> Span {
@@ -47,7 +47,7 @@ impl Command for Run {
     }
 
     fn prelude(&self, context: Context) -> Result<Self::Input> {
-        (Build { options: self.compiler_options.clone() }).execute(context)
+        (LeoBuild { options: self.compiler_options.clone() }).execute(context)
     }
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
@@ -62,7 +62,7 @@ impl Command for Run {
 }
 
 // A helper function to handle the run command.
-fn handle_run<N: Network>(command: Run, context: Context) -> Result<<Run as Command>::Output> {
+fn handle_run<N: Network>(command: LeoRun, context: Context) -> Result<<LeoRun as Command>::Output> {
     let mut inputs = command.inputs;
 
     // Compose the `run` command.

--- a/leo/cli/commands/update.rs
+++ b/leo/cli/commands/update.rs
@@ -19,7 +19,7 @@ use crate::cli::helpers::updater::Updater;
 
 /// Update Leo to the latest version
 #[derive(Debug, Parser)]
-pub struct Update {
+pub struct LeoUpdate {
     /// Lists all available versions of Leo
     #[clap(short = 'l', long)]
     list: bool,
@@ -28,7 +28,7 @@ pub struct Update {
     quiet: bool,
 }
 
-impl Command for Update {
+impl Command for LeoUpdate {
     type Input = ();
     type Output = ();
 


### PR DESCRIPTION
Two types of changes:

Many types that drive Parser from clap are renamed - this is because clap gives errors about ArgGroups sharing the same name otherwise, but mysteriously only when using the `dev` profile.

Some argument groups, in particular those under Query, had various conflicts that clap rejected, mostly when two arguments shared the same short name. Those have been resolved.