### PR TITLE
[Docs] Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ If the issue still persists, please [open an issue](https://github.com/ProvableH
 
 ## 📖 Documentation
 
-* [Hello World - Next Steps](https://developer.aleo.org/leo/hello)
-* [Leo Language Documentation](https://developer.aleo.org/leo/language)
+* [Hello World - Next Steps](https://docs.leo-lang.org/leo/hello)
+* [Leo Language Documentation](https://docs.leo-lang.org/leo/language)
 * [Leo ABNF Grammar](https://github.com/AleoHQ/grammars/blob/master/leo.abnf)
-* [Homepage](https://developer.aleo.org/overview/)
+* [Homepage](https://docs.leo-lang.org/overview/)
 
 ## 🤝 Contributing
  


### PR DESCRIPTION
This PR changes `developer.aleo.org` to `docs.leo-lang.org`.

Closes #28399 