### PR TITLE
[Feature] Print Statements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,9 +2793,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1061bdbbe9f6b7eff608380fc2bc27c511f180915c1b6bd9ab3c43f848392a52"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2823,9 +2822,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4c2cb2fb5fe072253de93ff27a27d02d9f6fa8aef15b8399d9aae03fa106f"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2854,9 +2852,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67c386f93ffbb7fbeba46a630bb837d5aa091173cc6ea46600cf7d4bf201b8e"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2869,9 +2866,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69da527dfb8a06b363fd9acae69d6365aa85073256bb15ef5ad339cb034bd5d"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2881,9 +2877,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8627c5f44cc7f4c4678600695f3f47ec2f8eb9f4f8393bb17f4c852fd314bb"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2892,9 +2887,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362fcfa5fe6b4d33390789d29f3319911c84defd1dea2743c4519b293f58fecc"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2903,9 +2897,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cddfa1c833dc94ce9b7535b85ed81cc5a34cf2561f1af4c2f6f5c528b26432e6"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "indexmap 2.6.0",
  "itertools 0.11.0",
@@ -2922,15 +2915,13 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4065b220b837d3f4bd96f35936c6a2933e19a2f699e636b0df3d8181f51a4c67"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d254a30e2845428af200f95158884faf72728aa6b1de46ac2d53af74dfa884"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2940,9 +2931,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3691543e4c0baa34ed530b12e0f301fa230992f612e1fc063cb43a3c7852f2cf"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -2956,9 +2946,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cea90b7bc5e098dcbd1bd9d728501edc85a87cbd739c2bc635562529cb1cd03"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2972,9 +2961,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5715abd9e1fb0a56e79f6ff6db1e9b8e87729478f7598958b122ef1b3ce88249"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2986,9 +2974,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a324ea89623793473a14358ca1fa141264f74462c950a29465f104415bff677"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2996,9 +2983,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234e943a1ee4add148e6cbff71c10e01fd455f38a96f447c4477385d3eb87747"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3007,9 +2993,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b5bf2e2feb77d7397a298776e18d03cf8dadb466bdc277fb74ff99b7957de6"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3020,9 +3005,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97574f286199b541a10534786e50c35ac2fe0f253e8bfc77b7845ddece4793a9"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3033,9 +3017,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a510f4c84e8008ad4428a57b59655c4039c65ee8078e486c144d30ab1e610c"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3045,9 +3028,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6bc5a0408577eb7f189aa046f5ac8ee4b8aa7bb966dfa81c68d8cea026c5a25"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3058,9 +3040,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed74b1e7be553d4fdd80927c6d12d30b61ad28314effc365e1ba91949926c655"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3072,9 +3053,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfcfc296f0400d2625c0ef610e1eb48a12867c56d632650a62ae2e26fde5a9a"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3084,9 +3064,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa04a8fe25fbc2158d4f3abaff90b1ed2448eae85a5fa97725b6d2ff9ce712e"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3098,9 +3077,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca93893f6d697f0f1938b114f0d4538c5fab2b131ba508fe543ecae4097042a"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3110,9 +3088,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90917fbec1e94134eb73c318672fa13e13e7dbd9813408bfdf142040cd054deb"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "anyhow",
  "indexmap 2.6.0",
@@ -3134,9 +3111,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a0ad6b84cec66a885a88552178767b1a781309f3a4fe8d2f4fa840fb151091"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3153,9 +3129,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a655d52f38795d6f037a1f76d3f0dbd3f835cb34fbb6918cdea6362aa6a9e020"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3176,9 +3151,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3128d85a6fbd3970f9d4f5877007c2b9a80ed8eea647f5079733f6b4ba93c6"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3192,9 +3166,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28905bc383be6c2e0ae8c0f0a02f40b0fa6642fa2e166bac8a32c7d75dd8163"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3204,18 +3177,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d8ac49336d82e4ed1d7d90f0403a917feea00d84951963c4799f8d961acd63"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9267b908876d5d29f011db164398765cc66a8d086e5de6fcd5ddc5f120752e2"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3224,9 +3195,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d667d3f4afe1e6692dac476f6ead3d2739ed60c9ef0f70db7767fa010e99928"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3236,9 +3206,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5832e7aecd318968406deffc0cea4e794f6902465c69771a997fe733124920"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3248,9 +3217,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89d7d37cdc1efb57dc0baaeb950a01532761d42d645c986202206d4493d2fa6"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3260,9 +3228,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dec34afefe1cb78a77d11f494cd654701b2b0b169c6aef8131a156b2b9db96d"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3272,9 +3239,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c7963b24dc45ec0663ded89bdf05986bf61c339b104c64d37622143c4cc13"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "rand",
  "rayon",
@@ -3287,9 +3253,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e8966ab9ec5300b20285d9054521785b63a95b501323bad8216066a90015ae"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3305,9 +3270,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151c38941f583a0ac28cf99e0af446fc7e6e39ea1e3895d722b91365091e3bf5"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3330,9 +3294,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df0d3b6bd6b853916c956e46746c33d470ca5bb5f5404d98b9c3f1fd6390cc3"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "anyhow",
  "rand",
@@ -3343,9 +3306,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100f73fcc90866ed7c7e14af4afd1b66a87b3bc4325aab8455e9120f6bd0dcb8"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -3364,9 +3326,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c002b3ab30383901bc0a684b8c1fdfb6b9f4aaa71e7a59e323e5558ccd1df4b"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -3377,9 +3338,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abd5008b0837ac2fe1d33dc2be4ea38af778c3a8cfcab0f1839a70cf85eb54e"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3391,9 +3351,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d096cf0c0cc0b205797a811f7cd8694cb487bb945f17058a5fc8710703c793a"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -3405,9 +3364,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3770f99778463ce8be6fb10f29a5737f889882ba358ea948d6c8e8a9021bd6"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -3418,9 +3376,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0f5641442b912623075331c51154fb447ba3b1990a28554417f55f1139a8667"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3430,9 +3387,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7747990ad94acb969cda70976b478ed40a0beb22583774434114e5419e5ea5d9"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "indexmap 2.6.0",
  "rayon",
@@ -3446,9 +3402,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abbc85999cce7f6c3cfff47db8bae834cb5eee374c5a06d9be959bb5bc5ce5f2"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3460,9 +3415,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25614b92aed358b842cd3d0993afca1c4c41b5901f3f8b4fc806d0a97bda797d"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3470,9 +3424,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710122e2513287c1e992fb4dd11d74f1cfbdb49f15c0f50a3bf8bab82caedb49"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3491,9 +3444,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aae558db942169cafcfa83544562155d870f1770c473a8f800f3cea92886882"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3513,9 +3465,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49609967badb249a3600f20d3f5a6600f727394f344800d30b1f89e0f278fe55"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -3527,9 +3478,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0496ffd4e01b9a2a7914d6afa04d3b6a8ff8fa85edb37c0b25108d0a8b636a52"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3551,9 +3501,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f76c9e570372079d5705e45233aee5d18e72f77f19232b4c910146c8cef023"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3577,9 +3526,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123712831bcb405db1eac34db195b07da96ab7787833750cbc52b03e966a2820"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3609,9 +3557,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39539619196b61e499db123e0e499c5a6ec61346ec1784d6350c9325146881d2"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3634,9 +3581,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5520850ffbfe8fd074608fded31f1a4fbc62100f83de1bb0f6b083b8b6e381"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "indexmap 2.6.0",
  "paste",
@@ -3649,9 +3595,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48155b6411c0735196e95668a7d8347b15a36ebae7dc91a824d292897f10bd8a"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "bincode",
  "once_cell",
@@ -3663,9 +3608,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fcbfa865d7b4a30922bcdb18adc15c5bf8ce2ea42250184d7d95655b493f7c"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3685,9 +3629,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b78577ade70f11743b6f76f6cf4b5fc16905b41caa499d691e0ae822d0340ab"
+version = "0.16.19"
+source = "git+https://github.com/ProvableHQ/snarkVM?rev=419ea51#419ea51c11e20a970c7475065ab31361b3503fa4"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,10 @@ default-features = false
 version = "1.11.0"
 
 [workspace.dependencies.snarkvm]
-version = "1.0.0"
+#version = "1.0.0"
+git = "https://github.com/ProvableHQ/snarkVM"
+#branch = "mainnet-leo"
+rev = "419ea51"
 
 [workspace.dependencies.serde]
 version = "1.0.213"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ version = "1.11.0"
 git = "https://github.com/ProvableHQ/snarkVM"
 #branch = "mainnet-leo"
 rev = "419ea51"
+features = [ "leo" ]
 
 [workspace.dependencies.serde]
 version = "1.0.213"

--- a/compiler/ast/src/functions/core_function.rs
+++ b/compiler/ast/src/functions/core_function.rs
@@ -289,6 +289,8 @@ pub enum CoreFunction {
 
     SignatureVerify,
     FutureAwait,
+
+    LeoPrint,
 }
 
 impl CoreFunction {
@@ -566,6 +568,8 @@ impl CoreFunction {
 
             (sym::signature, sym::verify) => Self::SignatureVerify,
             (sym::Future, sym::Await) => Self::FutureAwait,
+
+            (sym::Leo, sym::print) => Self::LeoPrint,
             _ => return None,
         })
     }
@@ -844,6 +848,8 @@ impl CoreFunction {
 
             Self::SignatureVerify => 3,
             Self::FutureAwait => 1,
+
+            Self::LeoPrint => 1,
         }
     }
 
@@ -1101,7 +1107,8 @@ impl CoreFunction {
             | CoreFunction::SHA3_512HashToScalar
             | CoreFunction::GroupToXCoordinate
             | CoreFunction::GroupToYCoordinate
-            | CoreFunction::SignatureVerify => false,
+            | CoreFunction::SignatureVerify
+            | CoreFunction::LeoPrint => false,
         }
     }
 }

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -367,6 +367,20 @@ impl<N: Network> ParserContext<'_, N> {
                 span,
                 id: self.node_builder.next_id(),
             })))
+        } else if let (1, Some(CoreFunction::LeoPrint)) =
+            (args.len(), CoreFunction::from_symbols(sym::Leo, method.name))
+        {
+            Ok(Expression::Access(AccessExpression::AssociatedFunction(AssociatedFunction {
+                variant: Identifier::new(sym::Leo, self.node_builder.next_id()),
+                name: method,
+                arguments: {
+                    let mut arguments = vec![receiver];
+                    arguments.extend(args);
+                    arguments
+                },
+                span,
+                id: self.node_builder.next_id(),
+            })))
         } else {
             // Attempt to parse the method call as a mapping operation.
             match (args.len(), CoreFunction::from_symbols(sym::Mapping, method.name)) {

--- a/compiler/passes/src/code_generation/visit_expressions.rs
+++ b/compiler/passes/src/code_generation/visit_expressions.rs
@@ -485,6 +485,13 @@ impl<'a> CodeGenerator<'a> {
                 writeln!(instruction, " {};", arguments[0]).expect("failed to write to string");
                 (String::new(), instruction)
             }
+            sym::Leo => {
+                // The only `Leo` function is `print`.
+                let mut instruction = "    print".to_string();
+                // Write the argument.
+                writeln!(instruction, " {};", arguments[0]).expect("failed to write to string");
+                (String::new(), instruction)
+            }
             _ => {
                 unreachable!("All core functions should be known at this phase of compilation")
             }

--- a/compiler/passes/src/type_checking/checker.rs
+++ b/compiler/passes/src/type_checking/checker.rs
@@ -1029,6 +1029,7 @@ impl<'a, N: Network> TypeChecker<'a, N> {
                 Some(Type::Boolean)
             }
             CoreFunction::FutureAwait => Some(Type::Unit),
+            CoreFunction::LeoPrint => Some(Type::Unit),
         }
     }
 

--- a/compiler/span/src/symbol.rs
+++ b/compiler/span/src/symbol.rs
@@ -203,6 +203,8 @@ symbols! {
     to_y_coordinate,
     verify,
     Await: "await",
+    Leo,
+    print,
 
     // types
     address,

--- a/tests/expectations/compiler/core/leo/print.out
+++ b/tests/expectations/compiler/core/leo/print.out
@@ -1,0 +1,12 @@
+namespace = "Compile"
+expectation = "Pass"
+outputs = [[{ compile = [{ initial_symbol_table = "229b300ba1fb667bae780df6c1e598af6c586a517fccee78a298fe63169448c7", type_checked_symbol_table = "3509730a3436802986c9c51de34562f1250665946ebc27403b75c9ca166b11bd", unrolled_symbol_table = "3509730a3436802986c9c51de34562f1250665946ebc27403b75c9ca166b11bd", initial_ast = "1d07f32afe49f5767c17e17932366aa6f25c06c4cf2b4b378a8e3bfd554b0233", unrolled_ast = "1d07f32afe49f5767c17e17932366aa6f25c06c4cf2b4b378a8e3bfd554b0233", ssa_ast = "c59311821bcbe4c39d3a3212549a779f3474cabb1999ea3c7d6973bd707a79d8", flattened_ast = "d29b344113b98c0c4e926ee6e45c9013882f4b4f54fbd553b89aebd19e9cf7c2", destructured_ast = "b63764b1d65e26c8e89f594b874ad6d04f8103415f3d85cf82cda4176d652b44", inlined_ast = "b63764b1d65e26c8e89f594b874ad6d04f8103415f3d85cf82cda4176d652b44", dce_ast = "b63764b1d65e26c8e89f594b874ad6d04f8103415f3d85cf82cda4176d652b44", bytecode = """
+program test.aleo;
+
+function main:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    add r0 r1 into r2;
+    print r2;
+    output r2 as u32.private;
+""", errors = "", warnings = "" }] }]]

--- a/tests/tests/compiler/core/leo/print.leo
+++ b/tests/tests/compiler/core/leo/print.leo
@@ -1,0 +1,12 @@
+/*
+namespace = "Compile"
+expectation = "Pass"
+*/
+
+program test.aleo {
+    transition main(a: u32, b: u32) -> u32 {
+        let result: u32 = a + b;
+        Leo::print(result);
+        return result;
+    }
+}


### PR DESCRIPTION
This PR adds support for print statements in Leo via core function calls, e.g `Leo::print`.
This is done by implementing a `print` instruction in an experimental branch of snarkVM.
While the opcode works, the output can be hard to parse when used in the Leo CLI.

For example, for this program:
```
program printer.aleo {
    transition main(a: u32, b: u32) -> u32 {
        let result: u32 = a + b;
        Leo::print(result);
        return result;
    }
}
```
the output of `leo execute main 1u32 2u32` looks like
```
> leo execute main 1u32 2u32
       Leo ✅ Compiled 'printer.aleo' into Aleo instructions
2550859538u32
3u32
3u32
3u32
.
.
.
```
This is because the program is executed and evaluated multiple times in a single call to `leo execute`. 
UX improvements are needed.