### PR TITLE
[Feature] CLI Update Notification.

### DIFF
--- a/leo/cli/cli.rs
+++ b/leo/cli/cli.rs
@@ -124,6 +124,11 @@ pub fn run_with_args(cli: CLI) -> Result<()> {
         })?;
     }
 
+    //  Check for updates. If not forced, it checks once per day.
+    if let Ok(true) = updater::Updater::check_for_updates(false) {
+        let _ = updater::Updater::print_cli();
+    }
+
     // Get custom root folder and create context for it.
     // If not specified, default context will be created in cwd.
     let context = handle_error(Context::new(cli.path, cli.home, false));
@@ -143,6 +148,7 @@ pub fn run_with_args(cli: CLI) -> Result<()> {
         Commands::Update { command } => command.try_execute(context),
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::cli::{

--- a/leo/cli/helpers/updater.rs
+++ b/leo/cli/helpers/updater.rs
@@ -16,12 +16,12 @@
 
 use leo_errors::{CliError, Result};
 
-use std::fmt::Write as _;
+use aleo_std;
 
 use colored::Colorize;
-use dirs;
-use self_update::{backends::github, version::bump_is_greater, Status};
+use self_update::{Status, backends::github, version::bump_is_greater};
 use std::{
+    fmt::Write as _,
     fs,
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -97,7 +97,7 @@ impl Updater {
 
     /// Read the latest version from the version file.
     pub fn read_latest_version() -> Result<Option<String>, CliError> {
-        let version_file_path = Self::get_version_file_path()?;
+        let version_file_path = Self::get_version_file_path();
         match fs::read_to_string(version_file_path) {
             Ok(version) => Ok(Some(version.trim().to_string())),
             Err(_) => Ok(None),
@@ -131,9 +131,9 @@ impl Updater {
     /// If a new version is found, write it to a cache file and alert in every call.
     pub fn check_for_updates(force: bool) -> Result<bool, CliError> {
         // Get the cache directory and relevant file paths.
-        let cache_dir = Self::get_cache_dir()?;
+        let cache_dir = Self::get_cache_dir();
         let last_check_file = cache_dir.join(Self::LEO_CACHE_LAST_CHECK_FILE);
-        let version_file = Self::get_version_file_path()?;
+        let version_file = Self::get_version_file_path();
 
         // Determine if we should check for updates.
         let should_check = force || Self::should_check_for_updates(&last_check_file)?;
@@ -222,14 +222,12 @@ impl Updater {
     }
 
     /// Get the path to the file storing the latest version information.
-    fn get_version_file_path() -> Result<PathBuf, CliError> {
-        Self::get_cache_dir().map(|dir| dir.join(Self::LEO_CACHE_VERSION_FILE))
+    fn get_version_file_path() -> PathBuf {
+        Self::get_cache_dir().join(Self::LEO_CACHE_VERSION_FILE)
     }
 
     /// Get the cache directory for Leo.
-    fn get_cache_dir() -> Result<PathBuf, CliError> {
-        dirs::cache_dir()
-            .ok_or_else(|| CliError::cli_runtime_error("Failed to get cache directory".to_string()))
-            .map(|dir| dir.join("leo"))
+    fn get_cache_dir() -> PathBuf {
+        aleo_std::aleo_dir().join("leo")
     }
 }


### PR DESCRIPTION
This PR addresses the comments in [this](https://github.com/ProvableHQ/leo/pull/28345) PR.
Shoutout to @ungaro for doing all the heavy lifting!

Closes #28345.

From the original PR.

## Motivation

Implemented an update notification system to keep users informed about new versions of the Leo CLI tool. 
This PR introduces the following enhancements to the update notification system:

1. **Conditional Update Checks**: The update notification system performs checks based on a time interval (currently set to once per day) or when forced, reducing unnecessary network requests. It writes the last check timestamp and latest version to cache files. This check runs on any command with arguments.

2. **Integration with Help and Version Commands**: Update notifications are also integrated into the help (`--help`) and version (`--version`) command outputs. These commands do not trigger an update check; instead, they read from the cached latest version file.

Closes #28335 


### npm (Node.js package manager):
- Checks for updates to npm itself weekly
- Notifies users of available updates during npm CLI usage

### Homebrew (macOS package manager):
- Auto-updates itself by default when running `brew install` or `brew upgrade`
- Can be configured to check less frequently

### Cargo (Rust package manager):
- Does not automatically check for updates to itself
- Users typically update Cargo by updating their Rust installation

### Git:
- Does not automatically check for updates to itself
- Users typically update Git through their system package manager

### VS Code:
- Checks for updates to itself on startup, but not more than once per day
- Users can manually check through the UI

These examples show that while practices vary, many popular tools do implement some form of periodic self-update checking rather than checking on every invocation. This approach balances keeping users informed with avoiding excessive network requests and potential API rate limiting issues. (more about rate-limiting below)

Regarding checking every time, you'll still need some cache files. Once an update is found, it's unnecessary to check for new updates as `leo update` will still update to the latest version. Consider a scenario where there's an update from 2.1.0 to 2.2.0, and then a new update to 2.3.0, both happening on the same day. The only benefit of not using cache files would be to catch the 2.3.0 update notification immediately.

For `--help` and `--version` options, users often want to quickly check something (like leo version or a command reference) and may not prefer a network request delay.

Also, caching files doesn't prevent consistently reminding users of an update. It's consistently checking from the cache files and providing the notification in subsequent requests.

Moreover, frequent update checks might lead to rate limiting issues with GitHub's API. Many projects hosted on GitHub use their API for version checks, and GitHub does impose rate limits. For instance, unauthenticated requests are limited to 60 per hour per IP address. This could potentially cause problems for users in shared environments or those who frequently use the tool.

Caching also helps in offline scenarios, allowing the tool to provide the last known update information even when a network connection isn't available. if you're offline, you'll see some real lag as the connection will have to fail.

While the option to skip the update check is a good idea, having a reasonable default interval (like once a day) with the option to force a check seems to balance user awareness with system performance and API usage considerations. 