### PR TITLE
Error on futures in arrays, structs, or mappings.

### DIFF
--- a/compiler/passes/src/type_checking/checker.rs
+++ b/compiler/passes/src/type_checking/checker.rs
@@ -1087,6 +1087,8 @@ impl<'a, N: Network> TypeChecker<'a, N> {
                 }
                 // Check that the array element type is valid.
                 match array_type.element_type() {
+                    // Array elements cannot be futures.
+                    Type::Future(_) => self.emit_err(TypeCheckerError::array_element_cannot_be_future(span)),
                     // Array elements cannot be tuples.
                     Type::Tuple(_) => self.emit_err(TypeCheckerError::array_element_cannot_be_tuple(span)),
                     // Array elements cannot be records.

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -898,4 +898,18 @@ create_messages!(
         msg: format!("Cannot define a function with no parameters."),
         help: None,
     }
+
+    @formatted
+    composite_data_type_cannot_contain_future {
+        args: (data_type: impl Display),
+        msg: format!("A {data_type} cannot contain a future."),
+        help: None,
+    }
+
+    @formatted
+    array_element_cannot_be_future {
+        args: (),
+        msg: format!("An array cannot have a future as an element type."),
+        help: None,
+    }
 );

--- a/tests/expectations/compiler/futures/future_in_composite_fail.out
+++ b/tests/expectations/compiler/futures/future_in_composite_fail.out
@@ -1,0 +1,24 @@
+namespace = "Compile"
+expectation = "Fail"
+outputs = ["""
+Error [ETYC0372114]: A struct cannot contain a future.
+    --> compiler-test:7:9
+     |
+   7 |         member: Future,
+     |         ^^^^^^
+Error [ETYC0372031]: A mapping's key cannot be a future
+    --> compiler-test:4:5
+     |
+   4 |     mapping x: Future => Future;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372031]: A mapping's value cannot be a future
+    --> compiler-test:4:5
+     |
+   4 |     mapping x: Future => Future;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372115]: An array cannot have a future as an element type.
+    --> compiler-test:12:9
+     |
+  12 |         let an_array: [Future; 1] = [future];
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""]

--- a/tests/tests/compiler/futures/future_in_composite_fail.leo
+++ b/tests/tests/compiler/futures/future_in_composite_fail.leo
@@ -1,0 +1,22 @@
+/*
+namespace = "Compile"
+expectation = "Fail"
+*/
+
+program test.aleo {
+    mapping x: Future => Future;
+
+    struct S {
+        member: Future,
+    }
+
+    async transition main() -> Future {
+        let future: Future = finish();
+        let an_array: [Future; 1] = [future];
+        return an_array[0u32];
+    }
+
+    async function finish() {
+        assert_eq(1u8, 1u8);
+    }
+}


### PR DESCRIPTION
This already wouldn't work, but would either give misleading error messages or would compile to invalid bytecode.