### PR TITLE
[Fix] Select fee based on consensus height

### DIFF
--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -193,7 +193,7 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
             }
             None => {
                 // Make sure the user has enough public balance to pay for the deployment.
-                check_balance(&private_key, endpoint, &network.to_string(), context.clone(), total_cost)?;
+                check_balance(&private_key, endpoint, &network.to_string(), &context, total_cost)?;
                 let fee_authorization = vm.authorize_fee_public(
                     &private_key,
                     total_cost,

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -160,19 +160,24 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
         // Initialize the VM.
         let vm = VM::from(store)?;
 
-        // Compute the minimum deployment cost.
-        let (mut total_cost, (storage_cost, synthesis_cost, namespace_cost)) = deployment_cost(&deployment)?;
+        let base_fee = match command.fee_options.base_fee {
+            Some(base_fee) => base_fee,
+            None => {
+                // Compute the minimum deployment cost.
+                let (base_fee, (storage_cost, synthesis_cost, namespace_cost)) = deployment_cost(&deployment)?;
 
-        // Display the deployment cost breakdown using `credit` denomination.
-        total_cost += command.fee_options.priority_fee;
-        deploy_cost_breakdown(
-            name,
-            total_cost as f64 / 1_000_000.0,
-            storage_cost as f64 / 1_000_000.0,
-            synthesis_cost as f64 / 1_000_000.0,
-            namespace_cost as f64 / 1_000_000.0,
-            command.fee_options.priority_fee as f64 / 1_000_000.0,
-        )?;
+                // Display the deployment cost breakdown using `credit` denomination.
+                deploy_cost_breakdown(
+                    name,
+                    base_fee as f64 / 1_000_000.0,
+                    storage_cost as f64 / 1_000_000.0,
+                    synthesis_cost as f64 / 1_000_000.0,
+                    namespace_cost as f64 / 1_000_000.0,
+                    command.fee_options.priority_fee as f64 / 1_000_000.0,
+                )?;
+                base_fee
+            }
+        };
 
         // Initialize an RNG.
         let rng = &mut rand::thread_rng();
@@ -184,7 +189,7 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
                 let fee_authorization = vm.authorize_fee_private(
                     &private_key,
                     fee_record,
-                    total_cost,
+                    base_fee,
                     command.fee_options.priority_fee,
                     deployment_id,
                     rng,
@@ -193,10 +198,16 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
             }
             None => {
                 // Make sure the user has enough public balance to pay for the deployment.
-                check_balance(&private_key, endpoint, &network.to_string(), &context, total_cost)?;
+                check_balance(
+                    &private_key,
+                    endpoint,
+                    &network.to_string(),
+                    &context,
+                    base_fee + command.fee_options.priority_fee,
+                )?;
                 let fee_authorization = vm.authorize_fee_public(
                     &private_key,
-                    total_cost,
+                    base_fee,
                     command.fee_options.priority_fee,
                     deployment_id,
                     rng,
@@ -247,13 +258,13 @@ fn handle_deploy<A: Aleo<Network = N, BaseField = N::Field>, N: Network>(
 // A helper function to display a cost breakdown of the deployment.
 fn deploy_cost_breakdown(
     name: &String,
-    total_cost: f64,
+    base_fee: f64,
     storage_cost: f64,
     synthesis_cost: f64,
     namespace_cost: f64,
     priority_fee: f64,
 ) -> Result<()> {
-    println!("\nBase deployment cost for '{}' is {} credits.\n", name.bold(), total_cost);
+    println!("\nBase deployment cost for '{}' is {} credits.\n", name.bold(), base_fee);
     // Display the cost breakdown in a table.
     let data = [
         [name, "Cost (credits)"],
@@ -261,7 +272,7 @@ fn deploy_cost_breakdown(
         ["Program Synthesis", &format!("{:.6}", synthesis_cost)],
         ["Namespace", &format!("{:.6}", namespace_cost)],
         ["Priority Fee", &format!("{:.6}", priority_fee)],
-        ["Total", &format!("{:.6}", total_cost)],
+        ["Total", &format!("{:.6}", base_fee + priority_fee)],
     ];
     let mut out = Vec::new();
     text_tables::render(&mut out, data).map_err(CliError::table_render_failed)?;

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -224,16 +224,21 @@ fn handle_execute<A: Aleo>(
             }
             // Otherwise, default to the one provided in `fee_options`.
             else {
-                println!(
-                    "Failed to get the latest block height. Defaulting to V{}.",
-                    command.fee_options.consensus_version
-                );
-                match command.fee_options.consensus_version {
-                    1 => execution_cost_v1(&vm.process().read(), execution)?,
-                    2 => execution_cost_v2(&vm.process().read(), execution)?,
-                    version => {
+                // Get the consensus version from the command.
+                let version = match command.fee_options.consensus_version {
+                    Some(1) => 1,
+                    None | Some(2) => 2,
+                    Some(version) => {
                         panic!("Invalid consensus version: {version}. Please specify a valid version.")
                     }
+                };
+                // Print a warning message.
+                println!("Failed to get the latest block height. Defaulting to V{version}.",);
+                // Use the provided version.
+                match version {
+                    1 => execution_cost_v1(&vm.process().read(), execution)?,
+                    2 => execution_cost_v2(&vm.process().read(), execution)?,
+                    _ => unreachable!(),
                 }
             }
         } else {

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -210,6 +210,8 @@ pub struct FeeOptions {
     pub(crate) yes: bool,
     #[clap(long, help = "Performs a dry-run of transaction generation")]
     pub(crate) dry_run: bool,
+    #[clap(long, help = "Base fee in microcredits. Automatically calculated if not provided.")]
+    pub(crate) base_fee: Option<u64>,
     #[clap(long, help = "Priority fee in microcredits. Defaults to 0.", default_value = "0")]
     pub(crate) priority_fee: u64,
     #[clap(long, help = "Private key to authorize fee expenditure.")]

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -220,8 +220,8 @@ pub struct FeeOptions {
         long
     )]
     record: Option<String>,
-    #[clap(long, help = "Consensus version to use for the transaction.", default_value = "2")]
-    pub(crate) consensus_version: u8,
+    #[clap(long, help = "Consensus version to use for the transaction.")]
+    pub(crate) consensus_version: Option<u8>,
 }
 
 /// Parses the record string. If the string is a ciphertext, then attempt to decrypt it. Lifted from snarkOS.

--- a/leo/cli/commands/query/mod.rs
+++ b/leo/cli/commands/query/mod.rs
@@ -17,26 +17,26 @@
 use super::*;
 use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 
-mod block;
-use block::LeoBlock;
+pub mod block;
+pub use block::LeoBlock;
 
 pub mod program;
 pub use program::LeoProgram;
 
-mod state_root;
-use state_root::StateRoot;
+pub mod state_root;
+pub use state_root::StateRoot;
 
-mod committee;
-use committee::LeoCommittee;
+pub mod committee;
+pub use committee::LeoCommittee;
 
-mod mempool;
-use mempool::LeoMempool;
+pub mod mempool;
+pub use mempool::LeoMempool;
 
-mod peers;
-use peers::LeoPeers;
+pub mod peers;
+pub use peers::LeoPeers;
 
-mod transaction;
-use transaction::LeoTransaction;
+pub mod transaction;
+pub use transaction::LeoTransaction;
 
 mod utils;
 use utils::*;


### PR DESCRIPTION
This PR allows for execution fees to be determined by block height. If the height is greater than the `CONSENSUS_V2_HEIGHT` then the new (cheaper) fee calculation is used.