### PR TITLE
[Bug] Emit a warning when `self.caller` is used as a `record` owner.

### DIFF
--- a/compiler/compiler/src/test_compiler.rs
+++ b/compiler/compiler/src/test_compiler.rs
@@ -82,7 +82,8 @@ fn run_test(test: &str, dce_enabled: bool, handler: &Handler) -> Result<String, 
             .extend_if_error(disassemble_from_str::<TestnetV0>(&program_name, &bytecode).map_err(|err| err.into()))?;
         import_stubs.insert(Symbol::intern(&program_name), stub);
 
-        if handler.err_count() != 0 || handler.warning_count() != 0 {
+        // Only error out if there are errors. Warnings are okay but we still want to print them later.
+        if handler.err_count() != 0 {
             return Err(());
         }
 
@@ -98,7 +99,7 @@ fn runner(source: &str) -> String {
         let handler = Handler::new(buf.clone());
 
         match run_test(source, dce_enabled, &handler) {
-            Ok(x) => x,
+            Ok(x) => format!("{}{}", buf.extract_warnings(), x),
             Err(()) => format!("{}{}", buf.extract_errs(), buf.extract_warnings()),
         }
     }

--- a/errors/src/errors/type_checker/type_checker_warning.rs
+++ b/errors/src/errors/type_checker/type_checker_warning.rs
@@ -52,4 +52,11 @@ create_messages!(
         msg: format!("The type checker has exceeded the max depth of nested conditional blocks: {max}."),
         help: Some("Re-run with a larger maximum depth using the `--conditional_block_max_depth` build option. Ex: `leo run main --conditional_block_max_depth 25`.".to_string()),
     }
+
+    @formatted
+    caller_as_record_owner {
+        args: (record_name: impl Display),
+        msg: format!("`self.caller` used as the owner of record `{record_name}`"),
+        help: Some("`self.caller` may refer to a program address, which cannot spend records.".to_string()),
+    }
 );

--- a/tests/expectations/compiler/array/array_in_composite_data_types.out
+++ b/tests/expectations/compiler/array/array_in_composite_data_types.out
@@ -13,7 +13,7 @@ function foo:
     cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r1 as [u8; 8u32];
     cast r1 into r2 as bar;
     cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r3 as [u8; 8u32];
-    cast self.caller r3 into r4 as floo.record;
+    cast self.signer r3 into r4 as floo.record;
     output r0[0u32][0u32] as boolean.private;
     output r2 as bar.private;
     output r4 as floo.record;
@@ -33,7 +33,7 @@ function foo:
     cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r1 as [u8; 8u32];
     cast r1 into r2 as bar;
     cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r3 as [u8; 8u32];
-    cast self.caller r3 into r4 as floo.record;
+    cast self.signer r3 into r4 as floo.record;
     output r0[0u32][0u32] as boolean.private;
     output r2 as bar.private;
     output r4 as floo.record;

--- a/tests/expectations/compiler/array/array_write.out
+++ b/tests/expectations/compiler/array/array_write.out
@@ -64,7 +64,7 @@ function in_conditional:
 
 function f_record:
     async f_record 1u8 into r0;
-    cast self.caller 1u8 into r1 as R.record;
+    cast self.signer 1u8 into r1 as R.record;
     cast r1.owner 2u8 into r2 as R.record;
     output r2 as R.record;
     output r0 as test.aleo/f_record.future;
@@ -230,7 +230,7 @@ function in_conditional:
 
 function f_record:
     async f_record 1u8 into r0;
-    cast self.caller 1u8 into r1 as R.record;
+    cast self.signer 1u8 into r1 as R.record;
     cast r1.owner 2u8 into r2 as R.record;
     output r2 as R.record;
     output r0 as test.aleo/f_record.future;

--- a/tests/expectations/compiler/core/cheatcodes/valid_cheatcodes.out
+++ b/tests/expectations/compiler/core/cheatcodes/valid_cheatcodes.out
@@ -12,7 +12,7 @@ mapping Yo:
 function main_dep:
     input r0 as u32.private;
     async main_dep r0 1u32 into r1;
-    cast self.caller 1u32 into r2 as yeets.record;
+    cast self.signer 1u32 into r2 as yeets.record;
     output r2 as yeets.record;
     output r1 as test_dep.aleo/main_dep.future;
 
@@ -52,7 +52,7 @@ mapping Yo:
 function main_dep:
     input r0 as u32.private;
     async main_dep r0 1u32 into r1;
-    cast self.caller 1u32 into r2 as yeets.record;
+    cast self.signer 1u32 into r2 as yeets.record;
     output r2 as yeets.record;
     output r1 as test_dep.aleo/main_dep.future;
 

--- a/tests/expectations/compiler/examples/board.out
+++ b/tests/expectations/compiler/examples/board.out
@@ -13,7 +13,7 @@ record board_state:
 function new_board_state:
     input r0 as u64.private;
     input r1 as address.private;
-    cast self.caller 0u64 0u64 r0 self.caller r1 false into r2 as board_state.record;
+    cast self.signer 0u64 0u64 r0 self.caller r1 false into r2 as board_state.record;
     output r2 as board_state.record;
 
 function start_board:
@@ -57,7 +57,7 @@ record board_state:
 function new_board_state:
     input r0 as u64.private;
     input r1 as address.private;
-    cast self.caller 0u64 0u64 r0 self.caller r1 false into r2 as board_state.record;
+    cast self.signer 0u64 0u64 r0 self.caller r1 false into r2 as board_state.record;
     output r2 as board_state.record;
 
 function start_board:

--- a/tests/expectations/compiler/examples/lottery.out
+++ b/tests/expectations/compiler/examples/lottery.out
@@ -9,7 +9,7 @@ mapping num_winners:
     value as u8.public;
 
 function play:
-    cast self.caller into r0 as Ticket.record;
+    cast self.signer into r0 as Ticket.record;
     async play into r1;
     output r0 as Ticket.record;
     output r1 as lottery.aleo/play.future;
@@ -36,7 +36,7 @@ mapping num_winners:
     value as u8.public;
 
 function play:
-    cast self.caller into r0 as Ticket.record;
+    cast self.signer into r0 as Ticket.record;
     async play into r1;
     output r0 as Ticket.record;
     output r1 as lottery.aleo/play.future;

--- a/tests/expectations/compiler/examples/vote.out
+++ b/tests/expectations/compiler/examples/vote.out
@@ -33,9 +33,9 @@ mapping disagree_votes:
 
 function propose:
     input r0 as ProposalInfo.public;
-    assert.eq self.caller r0.proposer;
+    assert.eq self.signer r0.proposer;
     hash.bhp256 r0.title into r1 as field;
-    cast self.caller r1 r0 into r2 as Proposal.record;
+    cast self.signer r1 r0 into r2 as Proposal.record;
     async propose r1 into r3;
     output r2 as Proposal.record;
     output r3 as vote.aleo/propose.future;
@@ -115,9 +115,9 @@ mapping disagree_votes:
 
 function propose:
     input r0 as ProposalInfo.public;
-    assert.eq self.caller r0.proposer;
+    assert.eq self.signer r0.proposer;
     hash.bhp256 r0.title into r1 as field;
-    cast self.caller r1 r0 into r2 as Proposal.record;
+    cast self.signer r1 r0 into r2 as Proposal.record;
     async propose r1 into r3;
     output r2 as Proposal.record;
     output r3 as vote.aleo/propose.future;

--- a/tests/expectations/compiler/function/dead_code_elimination.out
+++ b/tests/expectations/compiler/function/dead_code_elimination.out
@@ -41,6 +41,6 @@ function foo:
     is.eq r0 r1 into r4;
     mul r0 r1 into r5;
     ternary r4 r5 0u8 into r6;
-    cast self.caller r6 into r7 as dummy.record;
+    cast self.signer r6 into r7 as dummy.record;
     add r0 r1 into r8;
     output r8 as u8.private;

--- a/tests/expectations/compiler/futures/await_out_of_order.out
+++ b/tests/expectations/compiler/futures/await_out_of_order.out
@@ -6,6 +6,39 @@ Warning [WSAZ0374003]: The future `f2` is not awaited in the order in which they
      |         ^^
      |
      = While it is not required for futures to be awaited in order, there is some specific behavior that arises, which may affect the semantics of your program. See `https://github.com/AleoNet/snarkVM/issues/2570` for more context.
+program test.aleo;
+
+mapping foo:
+    key as u32.public;
+    value as u32.public;
+
+function main_inner:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    async main_inner r0 r1 into r2;
+    output r2 as test.aleo/main_inner.future;
+
+finalize main_inner:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    set r1 into foo[r0];
+// --- Next Program --- //
+import test.aleo;
+program basic.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call test.aleo/main_inner 0u32 0u32 into r2;
+    call test.aleo/main_inner 1u32 1u32 into r3;
+    async main r2 r3 into r4;
+    output r4 as basic.aleo/main.future;
+
+finalize main:
+    input r0 as test.aleo/main_inner.future;
+    input r1 as test.aleo/main_inner.future;
+    await r1;
+    await r0;
 
 DCE_DISABLED:
 Warning [WSAZ0374003]: The future `f2` is not awaited in the order in which they were passed in to the `async` function.
@@ -15,3 +48,36 @@ Warning [WSAZ0374003]: The future `f2` is not awaited in the order in which they
      |         ^^
      |
      = While it is not required for futures to be awaited in order, there is some specific behavior that arises, which may affect the semantics of your program. See `https://github.com/AleoNet/snarkVM/issues/2570` for more context.
+program test.aleo;
+
+mapping foo:
+    key as u32.public;
+    value as u32.public;
+
+function main_inner:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    async main_inner r0 r1 into r2;
+    output r2 as test.aleo/main_inner.future;
+
+finalize main_inner:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    set r1 into foo[r0];
+// --- Next Program --- //
+import test.aleo;
+program basic.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call test.aleo/main_inner 0u32 0u32 into r2;
+    call test.aleo/main_inner 1u32 1u32 into r3;
+    async main r2 r3 into r4;
+    output r4 as basic.aleo/main.future;
+
+finalize main:
+    input r0 as test.aleo/main_inner.future;
+    input r1 as test.aleo/main_inner.future;
+    await r1;
+    await r0;

--- a/tests/expectations/compiler/futures/future_type_inference.out
+++ b/tests/expectations/compiler/futures/future_type_inference.out
@@ -24,7 +24,7 @@ record Token:
 
 function mint_private:
     async mint_private into r0;
-    cast self.caller 100u64 into r1 as Token.record;
+    cast self.signer 100u64 into r1 as Token.record;
     output r1 as Token.record;
     output r0 as multi_token_support_program.aleo/mint_private.future;
 
@@ -77,7 +77,7 @@ record Token:
 
 function mint_private:
     async mint_private into r0;
-    cast self.caller 100u64 into r1 as Token.record;
+    cast self.signer 100u64 into r1 as Token.record;
     output r1 as Token.record;
     output r0 as multi_token_support_program.aleo/mint_private.future;
 

--- a/tests/expectations/compiler/futures/nested.out
+++ b/tests/expectations/compiler/futures/nested.out
@@ -45,6 +45,107 @@ Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2
      |     ^
      |
      = Ex: `f.await()` to await a future. Remove this warning by including the `--disable-conditional-branch-type-checking` flag.
+program test_dep.aleo;
+
+record yeets:
+    owner as address.private;
+    val as u32.private;
+
+mapping Yo:
+    key as u32.public;
+    value as u32.public;
+
+function main_dep:
+    input r0 as u32.private;
+    async main_dep r0 1u32 into r1;
+    cast self.signer 1u32 into r2 as yeets.record;
+    output r2 as yeets.record;
+    output r1 as test_dep.aleo/main_dep.future;
+
+finalize main_dep:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    set r1 into Yo[r0];
+    add r0 r1 into r2;
+// --- Next Program --- //
+import test_dep.aleo;
+program test.aleo;
+
+mapping ayo:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.private;
+    call test_dep.aleo/main_dep 10u32 into r1 r2;
+    call test_dep.aleo/main_dep 1u32 into r3 r4;
+    async main r2 r4 1u32 into r5;
+    add r2[0u32] r4[0u32] into r6;
+    add r6 1u32 into r7;
+    add r7 r2[0u32] into r8;
+    mul r2[0u32] 2u32 into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+    output r5 as test.aleo/main.future;
+
+finalize main:
+    input r0 as test_dep.aleo/main_dep.future;
+    input r1 as test_dep.aleo/main_dep.future;
+    input r2 as u32.public;
+    is.eq r2 1u32 into r3;
+    branch.eq r3 false to end_then_0_0;
+    await r0;
+    await r1;
+    branch.eq true true to end_otherwise_0_1;
+    position end_then_0_0;
+    position end_otherwise_0_1;
+    is.eq r2 2u32 into r4;
+    branch.eq r4 false to end_then_0_2;
+    set 1u32 into ayo[1u32];
+    branch.eq true true to end_otherwise_0_3;
+    position end_then_0_2;
+    position end_otherwise_0_3;
+    add r0[0u32] r1[0u32] into r5;
+    set r5 into ayo[1u32];
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+program wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call test.aleo/main 1u32 into r2 r3;
+    call test.aleo/main 1u32 into r4 r5;
+    call test.aleo/main 1u32 into r6 r7;
+    async main r3 r5 r7 into r8;
+    output r2 as u32.private;
+    output r8 as wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as test.aleo/main.future;
+    input r1 as test.aleo/main.future;
+    input r2 as test.aleo/main.future;
+    await r0;
+    await r1;
+    await r2;
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+import wrapper.aleo;
+program big_wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call wrapper.aleo/main 10u32 10u32 into r2 r3;
+    async main r3 into r4;
+    output r4[0u32][0u32][0u32][0u32] as u32.private;
+    output r4 as big_wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as wrapper.aleo/main.future;
+    await r0;
 
 DCE_DISABLED:
 Warning [WSAZ0374002]: The type checker has exceeded the max depth of nested conditional blocks: 0.
@@ -93,3 +194,104 @@ Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2
      |     ^
      |
      = Ex: `f.await()` to await a future. Remove this warning by including the `--disable-conditional-branch-type-checking` flag.
+program test_dep.aleo;
+
+record yeets:
+    owner as address.private;
+    val as u32.private;
+
+mapping Yo:
+    key as u32.public;
+    value as u32.public;
+
+function main_dep:
+    input r0 as u32.private;
+    async main_dep r0 1u32 into r1;
+    cast self.signer 1u32 into r2 as yeets.record;
+    output r2 as yeets.record;
+    output r1 as test_dep.aleo/main_dep.future;
+
+finalize main_dep:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    set r1 into Yo[r0];
+    add r0 r1 into r2;
+// --- Next Program --- //
+import test_dep.aleo;
+program test.aleo;
+
+mapping ayo:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.private;
+    call test_dep.aleo/main_dep 10u32 into r1 r2;
+    call test_dep.aleo/main_dep 1u32 into r3 r4;
+    async main r2 r4 1u32 into r5;
+    add r2[0u32] r4[0u32] into r6;
+    add r6 1u32 into r7;
+    add r7 r2[0u32] into r8;
+    mul r2[0u32] 2u32 into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+    output r5 as test.aleo/main.future;
+
+finalize main:
+    input r0 as test_dep.aleo/main_dep.future;
+    input r1 as test_dep.aleo/main_dep.future;
+    input r2 as u32.public;
+    is.eq r2 1u32 into r3;
+    branch.eq r3 false to end_then_0_0;
+    await r0;
+    await r1;
+    branch.eq true true to end_otherwise_0_1;
+    position end_then_0_0;
+    position end_otherwise_0_1;
+    is.eq r2 2u32 into r4;
+    branch.eq r4 false to end_then_0_2;
+    set 1u32 into ayo[1u32];
+    branch.eq true true to end_otherwise_0_3;
+    position end_then_0_2;
+    position end_otherwise_0_3;
+    add r0[0u32] r1[0u32] into r5;
+    set r5 into ayo[1u32];
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+program wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call test.aleo/main 1u32 into r2 r3;
+    call test.aleo/main 1u32 into r4 r5;
+    call test.aleo/main 1u32 into r6 r7;
+    async main r3 r5 r7 into r8;
+    output r2 as u32.private;
+    output r8 as wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as test.aleo/main.future;
+    input r1 as test.aleo/main.future;
+    input r2 as test.aleo/main.future;
+    await r0;
+    await r1;
+    await r2;
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+import wrapper.aleo;
+program big_wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call wrapper.aleo/main 10u32 10u32 into r2 r3;
+    async main r3 into r4;
+    output r4[0u32][0u32][0u32][0u32] as u32.private;
+    output r4 as big_wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as wrapper.aleo/main.future;
+    await r0;

--- a/tests/expectations/compiler/futures/partial_type_specification.out
+++ b/tests/expectations/compiler/futures/partial_type_specification.out
@@ -45,6 +45,117 @@ Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2
      |     ^
      |
      = Ex: `f.await()` to await a future. Remove this warning by including the `--disable-conditional-branch-type-checking` flag.
+program test_dep.aleo;
+
+record yeets:
+    owner as address.private;
+    val as u32.private;
+
+mapping Yo:
+    key as u32.public;
+    value as u32.public;
+
+function main_dep:
+    input r0 as u32.private;
+    async main_dep r0 1u32 into r1;
+    cast self.signer 1u32 into r2 as yeets.record;
+    output r2 as yeets.record;
+    output r1 as test_dep.aleo/main_dep.future;
+
+finalize main_dep:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    set r1 into Yo[r0];
+    add r0 r1 into r2;
+
+function main_dep_2:
+    input r0 as u32.private;
+    async main_dep_2 into r1;
+    cast self.signer 1u32 into r2 as yeets.record;
+    output r2 as yeets.record;
+    output r1 as test_dep.aleo/main_dep_2.future;
+
+finalize main_dep_2:
+    set 1u32 into Yo[1u32];
+// --- Next Program --- //
+import test_dep.aleo;
+program test.aleo;
+
+mapping ayo:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.private;
+    call test_dep.aleo/main_dep 10u32 into r1 r2;
+    call test_dep.aleo/main_dep 1u32 into r3 r4;
+    async main r2 r4 1u32 into r5;
+    add r2[0u32] r4[0u32] into r6;
+    add r6 1u32 into r7;
+    add r7 r2[0u32] into r8;
+    mul r2[0u32] 2u32 into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+    output r5 as test.aleo/main.future;
+
+finalize main:
+    input r0 as test_dep.aleo/main_dep.future;
+    input r1 as test_dep.aleo/main_dep.future;
+    input r2 as u32.public;
+    is.eq r2 1u32 into r3;
+    branch.eq r3 false to end_then_0_0;
+    await r0;
+    await r1;
+    branch.eq true true to end_otherwise_0_1;
+    position end_then_0_0;
+    position end_otherwise_0_1;
+    is.eq r2 2u32 into r4;
+    branch.eq r4 false to end_then_0_2;
+    set 1u32 into ayo[1u32];
+    branch.eq true true to end_otherwise_0_3;
+    position end_then_0_2;
+    position end_otherwise_0_3;
+    add r0[0u32] r1[0u32] into r5;
+    set r5 into ayo[1u32];
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+program wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call test.aleo/main 1u32 into r2 r3;
+    call test.aleo/main 1u32 into r4 r5;
+    call test.aleo/main 1u32 into r6 r7;
+    async main r3 r5 r7 into r8;
+    output r2 as u32.private;
+    output r8 as wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as test.aleo/main.future;
+    input r1 as test.aleo/main.future;
+    input r2 as test.aleo/main.future;
+    await r0;
+    await r1;
+    await r2;
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+import wrapper.aleo;
+program big_wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call wrapper.aleo/main 10u32 10u32 into r2 r3;
+    async main r3 into r4;
+    output r4[0u32][0u32][0u32][0u32] as u32.private;
+    output r4 as big_wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as wrapper.aleo/main.future;
+    await r0;
 
 DCE_DISABLED:
 Warning [WSAZ0374002]: The type checker has exceeded the max depth of nested conditional blocks: 0.
@@ -93,3 +204,114 @@ Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2
      |     ^
      |
      = Ex: `f.await()` to await a future. Remove this warning by including the `--disable-conditional-branch-type-checking` flag.
+program test_dep.aleo;
+
+record yeets:
+    owner as address.private;
+    val as u32.private;
+
+mapping Yo:
+    key as u32.public;
+    value as u32.public;
+
+function main_dep:
+    input r0 as u32.private;
+    async main_dep r0 1u32 into r1;
+    cast self.signer 1u32 into r2 as yeets.record;
+    output r2 as yeets.record;
+    output r1 as test_dep.aleo/main_dep.future;
+
+finalize main_dep:
+    input r0 as u32.public;
+    input r1 as u32.public;
+    set r1 into Yo[r0];
+    add r0 r1 into r2;
+
+function main_dep_2:
+    input r0 as u32.private;
+    async main_dep_2 into r1;
+    cast self.signer 1u32 into r2 as yeets.record;
+    output r2 as yeets.record;
+    output r1 as test_dep.aleo/main_dep_2.future;
+
+finalize main_dep_2:
+    set 1u32 into Yo[1u32];
+// --- Next Program --- //
+import test_dep.aleo;
+program test.aleo;
+
+mapping ayo:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.private;
+    call test_dep.aleo/main_dep 10u32 into r1 r2;
+    call test_dep.aleo/main_dep 1u32 into r3 r4;
+    async main r2 r4 1u32 into r5;
+    add r2[0u32] r4[0u32] into r6;
+    add r6 1u32 into r7;
+    add r7 r2[0u32] into r8;
+    mul r2[0u32] 2u32 into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+    output r5 as test.aleo/main.future;
+
+finalize main:
+    input r0 as test_dep.aleo/main_dep.future;
+    input r1 as test_dep.aleo/main_dep.future;
+    input r2 as u32.public;
+    is.eq r2 1u32 into r3;
+    branch.eq r3 false to end_then_0_0;
+    await r0;
+    await r1;
+    branch.eq true true to end_otherwise_0_1;
+    position end_then_0_0;
+    position end_otherwise_0_1;
+    is.eq r2 2u32 into r4;
+    branch.eq r4 false to end_then_0_2;
+    set 1u32 into ayo[1u32];
+    branch.eq true true to end_otherwise_0_3;
+    position end_then_0_2;
+    position end_otherwise_0_3;
+    add r0[0u32] r1[0u32] into r5;
+    set r5 into ayo[1u32];
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+program wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call test.aleo/main 1u32 into r2 r3;
+    call test.aleo/main 1u32 into r4 r5;
+    call test.aleo/main 1u32 into r6 r7;
+    async main r3 r5 r7 into r8;
+    output r2 as u32.private;
+    output r8 as wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as test.aleo/main.future;
+    input r1 as test.aleo/main.future;
+    input r2 as test.aleo/main.future;
+    await r0;
+    await r1;
+    await r2;
+// --- Next Program --- //
+import test_dep.aleo;
+import test.aleo;
+import wrapper.aleo;
+program big_wrapper.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    call wrapper.aleo/main 10u32 10u32 into r2 r3;
+    async main r3 into r4;
+    output r4[0u32][0u32][0u32][0u32] as u32.private;
+    output r4 as big_wrapper.aleo/main.future;
+
+finalize main:
+    input r0 as wrapper.aleo/main.future;
+    await r0;

--- a/tests/expectations/compiler/records/gates_is_allowed.out
+++ b/tests/expectations/compiler/records/gates_is_allowed.out
@@ -9,7 +9,7 @@ record Token:
 function main:
     input r0 as u64.private;
     input r1 as u64.private;
-    cast self.caller r0 r1 into r2 as Token.record;
+    cast self.signer r0 r1 into r2 as Token.record;
     output r2 as Token.record;
 
 DCE_DISABLED:
@@ -23,5 +23,5 @@ record Token:
 function main:
     input r0 as u64.private;
     input r1 as u64.private;
-    cast self.caller r0 r1 into r2 as Token.record;
+    cast self.signer r0 r1 into r2 as Token.record;
     output r2 as Token.record;

--- a/tests/expectations/compiler/records/record_declaration_out_of_order.out
+++ b/tests/expectations/compiler/records/record_declaration_out_of_order.out
@@ -9,7 +9,7 @@ function main:
     input r0 as u64.private;
     input r1 as u64.private;
     add r0 r1 into r2;
-    cast self.caller r2 into r3 as Token.record;
+    cast self.signer r2 into r3 as Token.record;
     output r3 as Token.record;
 
 DCE_DISABLED:
@@ -23,5 +23,5 @@ function main:
     input r0 as u64.private;
     input r1 as u64.private;
     add r0 r1 into r2;
-    cast self.caller r2 into r3 as Token.record;
+    cast self.signer r2 into r3 as Token.record;
     output r3 as Token.record;

--- a/tests/expectations/compiler/records/record_with_visibility.out
+++ b/tests/expectations/compiler/records/record_with_visibility.out
@@ -10,7 +10,7 @@ function main:
     input r0 as u64.private;
     input r1 as u64.private;
     add r0 r1 into r2;
-    cast self.caller r2 true into r3 as Token.record;
+    cast self.signer r2 true into r3 as Token.record;
     output r3 as Token.record;
 
 DCE_DISABLED:
@@ -25,5 +25,5 @@ function main:
     input r0 as u64.private;
     input r1 as u64.private;
     add r0 r1 into r2;
-    cast self.caller r2 true into r3 as Token.record;
+    cast self.signer r2 true into r3 as Token.record;
     output r3 as Token.record;

--- a/tests/expectations/compiler/records/self_caller_as_record_owner.out
+++ b/tests/expectations/compiler/records/self_caller_as_record_owner.out
@@ -1,0 +1,55 @@
+DCE_ENABLED:
+Warning [WTYC0372004]: `self.caller` used as the owner of record `Token`
+    --> compiler-test:8:20
+     |
+   8 |             owner: self.caller,
+     |                    ^^^^^^^^^^^
+     |
+     = `self.caller` may refer to a program address, which cannot spend records.
+Warning [WTYC0372004]: `self.caller` used as the owner of record `Token`
+    --> compiler-test:14:20
+     |
+  14 |             owner: self.caller,
+     |                    ^^^^^^^^^^^
+     |
+     = `self.caller` may refer to a program address, which cannot spend records.
+program test0.aleo;
+
+record Token:
+    owner as address.private;
+
+function foo:
+    cast self.caller into r0 as Token.record;
+    output r0 as Token.record;
+
+function bar:
+    cast self.caller into r0 as Token.record;
+    output r0 as Token.record;
+
+DCE_DISABLED:
+Warning [WTYC0372004]: `self.caller` used as the owner of record `Token`
+    --> compiler-test:8:20
+     |
+   8 |             owner: self.caller,
+     |                    ^^^^^^^^^^^
+     |
+     = `self.caller` may refer to a program address, which cannot spend records.
+Warning [WTYC0372004]: `self.caller` used as the owner of record `Token`
+    --> compiler-test:14:20
+     |
+  14 |             owner: self.caller,
+     |                    ^^^^^^^^^^^
+     |
+     = `self.caller` may refer to a program address, which cannot spend records.
+program test0.aleo;
+
+record Token:
+    owner as address.private;
+
+function foo:
+    cast self.caller into r0 as Token.record;
+    output r0 as Token.record;
+
+function bar:
+    cast self.caller into r0 as Token.record;
+    output r0 as Token.record;

--- a/tests/expectations/compiler/structs/external_record.out
+++ b/tests/expectations/compiler/structs/external_record.out
@@ -22,7 +22,7 @@ function wrapper_mint:
     input r0 as address.private;
     input r1 as u32.private;
     call child.aleo/mint self.caller 1u32 into r2;
-    cast self.caller r1 into r3 as B.record;
+    cast self.signer r1 into r3 as B.record;
     output r2 as child.aleo/A.record;
     output r3 as B.record;
 // --- Next Program --- //
@@ -67,7 +67,7 @@ function wrapper_mint:
     input r0 as address.private;
     input r1 as u32.private;
     call child.aleo/mint self.caller 1u32 into r2;
-    cast self.caller r1 into r3 as B.record;
+    cast self.signer r1 into r3 as B.record;
     output r2 as child.aleo/A.record;
     output r3 as B.record;
 // --- Next Program --- //

--- a/tests/expectations/compiler/structs/external_struct.out
+++ b/tests/expectations/compiler/structs/external_struct.out
@@ -36,7 +36,7 @@ function create:
     cast r10 into r11 as Bar;
     cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
-    cast self.caller 10u32 into r14 as Boo.record;
+    cast self.signer 10u32 into r14 as Boo.record;
     output r13 as Foo.private;
     output r14 as Boo.record;
 // --- Next Program --- //
@@ -77,7 +77,7 @@ function create_wrapper:
 function create_another_wrapper:
     call child.aleo/create into r0 r1;
     cast 1u32 2u32 into r2 as Woo;
-    cast self.caller 10u32 r2 into r3 as BooHoo.record;
+    cast self.signer 10u32 r2 into r3 as BooHoo.record;
     cast 3u32 4u32 into r4 as Woo;
     output r0 as Foo.private;
     output r1 as child.aleo/Boo.record;
@@ -159,7 +159,7 @@ function create:
     cast r10 into r11 as Bar;
     cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
-    cast self.caller 10u32 into r14 as Boo.record;
+    cast self.signer 10u32 into r14 as Boo.record;
     output r13 as Foo.private;
     output r14 as Boo.record;
 // --- Next Program --- //
@@ -228,7 +228,7 @@ function create_another_wrapper:
     cast r12 into r13 as Foo;
     call child.aleo/create into r14 r15;
     cast 1u32 2u32 into r16 as Woo;
-    cast self.caller 10u32 r16 into r17 as BooHoo.record;
+    cast self.signer 10u32 r16 into r17 as BooHoo.record;
     cast 3u32 4u32 into r18 as Woo;
     output r14 as Foo.private;
     output r15 as child.aleo/Boo.record;

--- a/tests/tests/compiler/array/array_in_composite_data_types.leo
+++ b/tests/tests/compiler/array/array_in_composite_data_types.leo
@@ -10,6 +10,6 @@ program test.aleo {
     }
 
     transition foo(a: [[bool; 8]; 8]) -> (bool, bar, floo) {
-        return (a[0u32][0u32], bar { data: [1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8] }, floo { owner: self.caller, data: [1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8] });
+        return (a[0u32][0u32], bar { data: [1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8] }, floo { owner: self.signer, data: [1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8, 1u8] });
     }
 }

--- a/tests/tests/compiler/array/array_write.leo
+++ b/tests/tests/compiler/array/array_write.leo
@@ -63,7 +63,7 @@ program test.aleo {
     async transition f_record() -> (R, Future) {
         let fut: Future = f_finalize(1u8);
         let r: R = R {
-            owner: self.caller,
+            owner: self.signer,
             x: 1u8,
         };
         r.x = 2u8;

--- a/tests/tests/compiler/core/cheatcodes/invalid_cheatcodes_fail.leo
+++ b/tests/tests/compiler/core/cheatcodes/invalid_cheatcodes_fail.leo
@@ -9,7 +9,7 @@ program test_dep.aleo {
 
     async transition main_dep(a:u32) -> (yeets, Future) {
         let f: Future = finalize_main_dep(a, 1u32);
-        let l: yeets = yeets {owner: self.caller, val: 1u32};
+        let l: yeets = yeets {owner: self.signer, val: 1u32};
         return (l, f);
     }
 

--- a/tests/tests/compiler/core/cheatcodes/valid_cheatcodes.leo
+++ b/tests/tests/compiler/core/cheatcodes/valid_cheatcodes.leo
@@ -9,7 +9,7 @@ program test_dep.aleo {
 
     async transition main_dep(a:u32) -> (yeets, Future) {
         let f: Future = finalize_main_dep(a, 1u32);
-        let l: yeets = yeets {owner: self.caller, val: 1u32};
+        let l: yeets = yeets {owner: self.signer, val: 1u32};
         return (l, f);
     }
 

--- a/tests/tests/compiler/examples/board.leo
+++ b/tests/tests/compiler/examples/board.leo
@@ -26,7 +26,7 @@ program test.aleo {
         opponent: address,
     ) -> board_state {
         return board_state {
-            owner: self.caller,
+            owner: self.signer,
             hits_and_misses: 0u64,
             played_tiles: 0u64,
             ships,

--- a/tests/tests/compiler/examples/lottery.leo
+++ b/tests/tests/compiler/examples/lottery.leo
@@ -10,7 +10,7 @@ program lottery.aleo {
 
     async transition play() -> (Ticket, Future) {
         let ticket: Ticket = Ticket {
-            owner: self.caller,
+            owner: self.signer,
         };
         return (ticket, finalize_play());
     }

--- a/tests/tests/compiler/examples/vote.leo
+++ b/tests/tests/compiler/examples/vote.leo
@@ -34,7 +34,7 @@ program vote.aleo {
     // Propose a new proposal to vote on.
     async transition propose(public info: ProposalInfo) -> (Proposal, Future) {
         // Authenticate proposer.
-        assert_eq(self.caller, info.proposer);
+        assert_eq(self.signer, info.proposer);
 
         // Generate a new proposal id.
         let id: field = BHP256::hash_to_field(info.title);
@@ -42,7 +42,7 @@ program vote.aleo {
 
         // Return a new record for the proposal.
         // Finalize the proposal id.
-        return (Proposal { owner: self.caller, id, info }, finalize_propose(id));
+        return (Proposal { owner: self.signer, id, info }, finalize_propose(id));
     }
     // Create a new proposal in the "tickets" mapping.
     async function finalize_propose(public id: field) {

--- a/tests/tests/compiler/function/dead_code_elimination.leo
+++ b/tests/tests/compiler/function/dead_code_elimination.leo
@@ -45,7 +45,7 @@ program test.aleo {
             e = inline_and_eliminate(a, b);
         }
         let f: dummy = dummy {
-            owner: self.caller,
+            owner: self.signer,
             data: e,
         };
         return a + b;

--- a/tests/tests/compiler/futures/future_type_inference.leo
+++ b/tests/tests/compiler/futures/future_type_inference.leo
@@ -25,7 +25,7 @@ program multi_token_support_program.aleo {
 
     async transition mint_private() -> (Token, Future) {
         let f: Future = finalize();
-        return (Token{owner: self.caller, amount: 100u64}, f);
+        return (Token{owner: self.signer, amount: 100u64}, f);
     }
 
     async function finalize() {

--- a/tests/tests/compiler/futures/nested.leo
+++ b/tests/tests/compiler/futures/nested.leo
@@ -9,7 +9,7 @@ program test_dep.aleo {
 
     async transition main_dep(a:u32) -> (yeets, Future) {
         let f: Future = finalize_main_dep(a, 1u32);
-        let l: yeets = yeets {owner: self.caller, val: 1u32};
+        let l: yeets = yeets {owner: self.signer, val: 1u32};
         return (l, f);
     }
 

--- a/tests/tests/compiler/futures/partial_type_specification.leo
+++ b/tests/tests/compiler/futures/partial_type_specification.leo
@@ -9,7 +9,7 @@ program test_dep.aleo {
 
     async transition main_dep(a:u32) -> (yeets, Future<Fn(u32, u32)>) {
         let f: Future<Fn(u32, u32)> = finalize_main_dep(a, 1u32);
-        let l: yeets = yeets {owner: self.caller, val: 1u32};
+        let l: yeets = yeets {owner: self.signer, val: 1u32};
         return (l, f);
     }
 
@@ -20,7 +20,7 @@ program test_dep.aleo {
 
     async transition main_dep_2(a:u32) -> (yeets, Future<Fn()>) {
         let f: Future<Fn()> = finalize_main_dep_2();
-        let l: yeets = yeets {owner: self.caller, val: 1u32};
+        let l: yeets = yeets {owner: self.signer, val: 1u32};
         return (l, f);
     }
 

--- a/tests/tests/compiler/records/gates_is_allowed.leo
+++ b/tests/tests/compiler/records/gates_is_allowed.leo
@@ -10,6 +10,6 @@ program test.aleo {
     }
 
     transition main(a: u64, b:u64) -> Token {
-        return Token { owner: self.caller, amount: a, gates: b};
+        return Token { owner: self.signer, amount: a, gates: b};
     }
 }

--- a/tests/tests/compiler/records/record_declaration_out_of_order.leo
+++ b/tests/tests/compiler/records/record_declaration_out_of_order.leo
@@ -8,6 +8,6 @@ program test.aleo {
     }
 
     transition main(a: u64, b:u64) -> Token {
-        return Token { amount: a + b, owner: self.caller};
+        return Token { amount: a + b, owner: self.signer };
     }
 }

--- a/tests/tests/compiler/records/record_with_visibility.leo
+++ b/tests/tests/compiler/records/record_with_visibility.leo
@@ -10,6 +10,6 @@ program test.aleo {
     }
 
     transition main(a: u64, b:u64) -> Token {
-        return Token { amount: a + b, owner: self.caller, flag: true};
+        return Token { amount: a + b, owner: self.signer, flag: true};
     }
 }

--- a/tests/tests/compiler/records/return_record_instead_of_unit_fail.leo
+++ b/tests/tests/compiler/records/return_record_instead_of_unit_fail.leo
@@ -7,7 +7,7 @@ program test.aleo {
 
     transition mint_credits(to: address, amount: u64) {
         return test_credits {
-            owner: self.caller,
+            owner: self.signer,
             amount
         };
     }

--- a/tests/tests/compiler/records/same_name_diff_type_fail.leo
+++ b/tests/tests/compiler/records/same_name_diff_type_fail.leo
@@ -7,7 +7,7 @@ program child.aleo {
 
     transition create() -> R {
         return R {
-            owner: self.caller,
+            owner: self.signer,
             x: 1u8,
         };
     }
@@ -24,7 +24,7 @@ program parent.aleo {
 
     transition check() -> bool {
         let r1: R = R {
-            owner: self.caller,
+            owner: self.signer,
             x: 1u16,
         };
 

--- a/tests/tests/compiler/records/self_caller_as_record_owner.leo
+++ b/tests/tests/compiler/records/self_caller_as_record_owner.leo
@@ -1,0 +1,19 @@
+program test0.aleo {
+    record Token {
+        owner: address,
+    }
+
+    transition foo() -> Token {
+        return Token {
+            owner: self.caller,
+        };
+    }
+
+    transition bar() -> Token {
+        let t: Token = Token {
+            owner: self.caller,
+        };
+
+        return t;
+    }
+}

--- a/tests/tests/compiler/structs/external_record.leo
+++ b/tests/tests/compiler/structs/external_record.leo
@@ -18,7 +18,7 @@ program parent.aleo {
         val: u32,
     }
     transition wrapper_mint(owner: address, val: u32) ->  (child.aleo/A, B) {
-        return (child.aleo/mint(self.caller, 1u32), B {owner: self.caller, val: val});
+        return (child.aleo/mint(self.caller, 1u32), B {owner: self.signer, val: val});
     }
 }
 

--- a/tests/tests/compiler/structs/external_struct.leo
+++ b/tests/tests/compiler/structs/external_struct.leo
@@ -27,7 +27,9 @@ program child.aleo {
     }
 
     transition create() -> (Foo, Boo) {
-        return (Foo {bar: [Bar {baz: [Baz {one: One {two: [Two {val1: 1u32, val2: 2u32}, Two {val1: 3u32, val2: 4u32}]}}, Baz {one: One {two: [Two {val1: 5u32, val2: 6u32}, Two {val1: 7u32, val2: 8u32}]}}]}]}, Boo {owner: self.caller, val: 10u32});
+        return (Foo {bar: [Bar {baz: [Baz {one: One {two: [Two {val1: 1u32, val2: 2u32}, Two {val1: 3u32, val2:
+        4u32}]}}, Baz {one: One {two: [Two {val1: 5u32, val2: 6u32}, Two {val1: 7u32, val2: 8u32}]}}]}]}, Boo {owner:
+        self.signer, val: 10u32});
     }
 }
 
@@ -56,7 +58,7 @@ program parent.aleo {
     transition create_another_wrapper() -> (Foo, child.aleo/Boo, BooHoo, Woo) {
         let f: Foo = Foo {bar: [Bar {baz: [Baz {one: One {two: [Two {val1: 1u32, val2: 2u32}, Two {val1: 3u32, val2: 4u32}]}}, Baz {one: One {two: [Two {val1: 5u32, val2: 6u32}, Two {val1: 7u32, val2: 8u32}]}}]}]};
         let (f1, b1): (Foo, child.aleo/Boo) = child.aleo/create();
-        return (f1, b1, BooHoo {owner: self.caller, val: 10u32, woo: Woo {a: 1u32, b: 2u32}}, Woo {a: 3u32, b: 4u32});
+        return (f1, b1, BooHoo {owner: self.signer, val: 10u32, woo: Woo {a: 1u32, b: 2u32}}, Woo {a: 3u32, b: 4u32});
     }
 
 }


### PR DESCRIPTION
## Motivation

Emit a warning when `self.caller` is used as a `record` owner. If `self.caller` is a program address, then this effectively burns the record.

For now, this only checks for the case where the record is initialized with `self.caller` as the `owner`. Alternatively, a record's `owner` could be reassigned to `self.caller` but that case is harder to detect without data flow analysis (imagine a long chain of temps etc.).

## Test Plan

Updated the testing infrastructure to always emit and expect warnings along with the compiled program. Previously, we would only emit the warnings and stop.

Add a simple test to check for the new warning even though many tests already trigger the warning.

Closes #28508