### PR TITLE
Fix a small type check error related to `MemberAccess` expressions

### DIFF
--- a/compiler/passes/src/type_checking/expression.rs
+++ b/compiler/passes/src/type_checking/expression.rs
@@ -89,12 +89,16 @@ impl TypeCheckingVisitor<'_> {
                         sym::caller => {
                             // Check that the operation is not invoked in a `finalize` block.
                             self.check_access_allowed("self.caller", false, input.name.span());
-                            return Type::Address;
+                            let ty = Type::Address;
+                            self.maybe_assert_type(&ty, expected, input.span());
+                            return ty;
                         }
                         sym::signer => {
                             // Check that operation is not invoked in a `finalize` block.
                             self.check_access_allowed("self.signer", false, input.name.span());
-                            return Type::Address;
+                            let ty = Type::Address;
+                            self.maybe_assert_type(&ty, expected, input.span());
+                            return ty;
                         }
                         _ => {
                             self.emit_err(TypeCheckerError::invalid_self_access(input.name.span()));

--- a/tests/expectations/compiler/bugs/b28614.out
+++ b/tests/expectations/compiler/bugs/b28614.out
@@ -1,0 +1,43 @@
+DCE_ENABLED:
+Error [ETYC0372117]: Expected type `u32` but type `address` was found.
+    --> compiler-test:3:22
+     |
+   3 |         let x: u32 = self.caller;
+     |                      ^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `address` was found.
+    --> compiler-test:4:21
+     |
+   4 |         let y: u8 = self.caller;
+     |                     ^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `address` was found.
+    --> compiler-test:7:13
+     |
+   7 |         z = self.caller;
+     |             ^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `field` but type `address` was found.
+    --> compiler-test:10:13
+     |
+  10 |         w = self.signer;
+     |             ^^^^^^^^^^^
+
+DCE_DISABLED:
+Error [ETYC0372117]: Expected type `u32` but type `address` was found.
+    --> compiler-test:3:22
+     |
+   3 |         let x: u32 = self.caller;
+     |                      ^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `address` was found.
+    --> compiler-test:4:21
+     |
+   4 |         let y: u8 = self.caller;
+     |                     ^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `address` was found.
+    --> compiler-test:7:13
+     |
+   7 |         z = self.caller;
+     |             ^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `field` but type `address` was found.
+    --> compiler-test:10:13
+     |
+  10 |         w = self.signer;
+     |             ^^^^^^^^^^^

--- a/tests/tests/compiler/bugs/b28614.leo
+++ b/tests/tests/compiler/bugs/b28614.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    transition bar() {
+        let x: u32 = self.caller;
+        let y: u8 = self.caller;
+        
+        let z: u8 = 0u8;
+        z = self.caller;
+
+        let w: field = 0field;
+        w = self.signer;
+    }
+}


### PR DESCRIPTION
## Motivation

Closes #28608

Compare the types of `self.caller` and `self.signer` to `expected` when handling them in the type checker.

## Test Plan

Added a single test that used to successfully compile but now fails with appropriate errors.
