### PR TITLE
Disallow records from being instantiated in async functions

### DIFF
--- a/compiler/passes/src/type_checking/expression.rs
+++ b/compiler/passes/src/type_checking/expression.rs
@@ -892,6 +892,12 @@ impl ExpressionVisitor for TypeCheckingVisitor<'_> {
         }
 
         if struct_.is_record {
+            // First, ensure that the current scope is not an async function. Records should not be instantiated in
+            // async functions
+            if self.scope_state.variant == Some(Variant::AsyncFunction) {
+                self.state.handler.emit_err(TypeCheckerError::records_not_allowed_inside_finalize(input.span()));
+            }
+
             // Records where the `owner` is `self.caller` can be problematic because `self.caller` can be a program
             // address and programs can't spend records. Emit a warning in this case.
             //

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -1003,4 +1003,11 @@ create_messages!(
         msg: format!("Cannot assign to the mapping `{var}`."),
         help: None,
     }
+
+    @formatted
+    records_not_allowed_inside_finalize {
+        args: (),
+        msg: format!("records cannot be instantiated in an async function context."),
+        help: None,
+    }
 );

--- a/tests/expectations/compiler/bugs/b28610.out
+++ b/tests/expectations/compiler/bugs/b28610.out
@@ -1,0 +1,23 @@
+DCE_ENABLED:
+Error [ETYC0372126]: records cannot be instantiated in an async function context.
+    --> compiler-test:11:24
+     |
+  11 |         let t: Token = Token { owner: addr };
+     |                        ^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372126]: records cannot be instantiated in an async function context.
+    --> compiler-test:12:16
+     |
+  12 |         assert(Token { owner: addr }.owner == addr);
+     |                ^^^^^^^^^^^^^^^^^^^^^
+
+DCE_DISABLED:
+Error [ETYC0372126]: records cannot be instantiated in an async function context.
+    --> compiler-test:11:24
+     |
+  11 |         let t: Token = Token { owner: addr };
+     |                        ^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372126]: records cannot be instantiated in an async function context.
+    --> compiler-test:12:16
+     |
+  12 |         assert(Token { owner: addr }.owner == addr);
+     |                ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/finalize/get_or_incorrect_type_fail.out
+++ b/tests/expectations/compiler/finalize/get_or_incorrect_type_fail.out
@@ -1,9 +1,4 @@
 DCE_ENABLED:
-Error [ETYC0372031]: A mapping's value cannot be a record
-    --> compiler-test:9:5
-     |
-   9 |     mapping tokens: address => Token;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372117]: Expected type `Token` but type `u128` was found.
     --> compiler-test:16:43
      |
@@ -56,11 +51,6 @@ Error [ETYC0372005]: Unknown variable `foo`
      |         ^^^
 
 DCE_DISABLED:
-Error [ETYC0372031]: A mapping's value cannot be a record
-    --> compiler-test:9:5
-     |
-   9 |     mapping tokens: address => Token;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372117]: Expected type `Token` but type `u128` was found.
     --> compiler-test:16:43
      |

--- a/tests/expectations/compiler/finalize/set_incorrect_type_fail.out
+++ b/tests/expectations/compiler/finalize/set_incorrect_type_fail.out
@@ -1,9 +1,4 @@
 DCE_ENABLED:
-Error [ETYC0372031]: A mapping's value cannot be a record
-    --> compiler-test:9:5
-     |
-   9 |     mapping tokens: address => Token;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372117]: Expected type `Token` but type `u128` was found.
     --> compiler-test:16:36
      |
@@ -56,11 +51,6 @@ Error [ETYC0372005]: Unknown variable `foo`
      |         ^^^
 
 DCE_DISABLED:
-Error [ETYC0372031]: A mapping's value cannot be a record
-    --> compiler-test:9:5
-     |
-   9 |     mapping tokens: address => Token;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372117]: Expected type `Token` but type `u128` was found.
     --> compiler-test:16:36
      |

--- a/tests/tests/compiler/bugs/b28610.leo
+++ b/tests/tests/compiler/bugs/b28610.leo
@@ -1,0 +1,14 @@
+program b28610.aleo {
+    record Token {
+        owner: address,
+    }
+
+    async transition foo() -> Future {
+        return bar(self.signer);
+    }
+
+    async function bar(addr: address) {
+        let t: Token = Token { owner: addr };
+        assert(Token { owner: addr }.owner == addr);
+    }
+}

--- a/tests/tests/compiler/finalize/get_or_incorrect_type_fail.leo
+++ b/tests/tests/compiler/finalize/get_or_incorrect_type_fail.leo
@@ -1,6 +1,6 @@
 
 program test.aleo {
-    record Token {
+    struct Token {
         owner: address,
         amount: u128,
     }

--- a/tests/tests/compiler/finalize/set_incorrect_type_fail.leo
+++ b/tests/tests/compiler/finalize/set_incorrect_type_fail.leo
@@ -1,6 +1,6 @@
 
 program test.aleo {
-    record Token {
+    struct Token {
         owner: address,
         amount: u128,
     }


### PR DESCRIPTION
## Motivation

Closes #28610

Emit an error when a record is instantiated in an async function context. We already do this for inputs and outputs of async functions.

Previously, we used to just emit invalid Aleo asm:
```console
Error [EUTL03710003]: Failed to parse the source file for `simple.aleo` into a valid Aleo program.
```
Now, we just emit a clean error:
<img width="662" alt="image" src="https://github.com/user-attachments/assets/80d9a851-acb8-4c61-89df-d37570432bc0" />

## Test Plan

Added a new test to check for the error