### PR TITLE
Disallow tuples and maps in `Signature::verify`

### DIFF
--- a/compiler/passes/src/type_checking/visitor.rs
+++ b/compiler/passes/src/type_checking/visitor.rs
@@ -792,6 +792,10 @@ impl TypeCheckingVisitor<'_> {
             CoreFunction::ChaChaRandU64 => Type::Integer(IntegerType::U64),
             CoreFunction::ChaChaRandU128 => Type::Integer(IntegerType::U128),
             CoreFunction::SignatureVerify => {
+                // Check that the third argument is not a mapping nor a tuple. We have to do this
+                // before the other checks below to appease the borrow checker
+                assert_not_mapping_tuple_unit(&arguments[2].0, arguments[2].1);
+
                 // Check that the first argument is a signature.
                 self.assert_type(&arguments[0].0, &Type::Signature, arguments[0].1);
                 // Check that the second argument is an address.

--- a/tests/expectations/compiler/bugs/b28611.out
+++ b/tests/expectations/compiler/bugs/b28611.out
@@ -1,0 +1,23 @@
+DCE_ENABLED:
+Error [ETYC0372117]: Expected anything but a mapping, tuple, or unit but type `(u32, u32)` was found.
+    --> compiler-test:7:47
+     |
+   7 |         let b: bool = sig.verify(self.caller, t);
+     |                                               ^
+Error [ETYC0372117]: Expected anything but a mapping, tuple, or unit but type `(u8 => u8)` was found.
+    --> compiler-test:8:47
+     |
+   8 |         let c: bool = sig.verify(self.caller, m);
+     |                                               ^
+
+DCE_DISABLED:
+Error [ETYC0372117]: Expected anything but a mapping, tuple, or unit but type `(u32, u32)` was found.
+    --> compiler-test:7:47
+     |
+   7 |         let b: bool = sig.verify(self.caller, t);
+     |                                               ^
+Error [ETYC0372117]: Expected anything but a mapping, tuple, or unit but type `(u8 => u8)` was found.
+    --> compiler-test:8:47
+     |
+   8 |         let c: bool = sig.verify(self.caller, m);
+     |                                               ^

--- a/tests/tests/compiler/bugs/b28611.leo
+++ b/tests/tests/compiler/bugs/b28611.leo
@@ -1,0 +1,10 @@
+program test.aleo {
+    mapping m: u8 => u8;
+
+    transition foo(sig: signature, x: u32, y: u32) {
+        // ensure that the caller provided the correct signature
+        let t: (u32, u32) = (x, y);
+        let b: bool = sig.verify(self.caller, t);
+        let c: bool = sig.verify(self.caller, m);
+    }
+}


### PR DESCRIPTION
## Motivation

Closes #28611

Looks like this was done properly for all other core functions. I went through them and they seem fine though they could probably use some more testing.

I opened #28618 - maybe we'll support tuples everywhere one day.

## Test Plan

Added a single test that triggers the error.