### PR TITLE
Update span.rs link in errors/README.md to use relative path

### DIFF
--- a/errors/README.md
+++ b/errors/README.md
@@ -22,7 +22,7 @@ The common section of this crate contains a few sub files:
 - [Backtraced Error](./src/common/backtraced.rs): Which contains the information needed to create a backtraceable error for Leo.
 - [Formatted Error](./src/common/formatted.rs): Which contains the information needed to create a formatted error for Leo.
 - [Macros](./src/common/macros.rs): Which contains the logic to make creating errors easy through a DSL. It also figures out the error codes for each error via a **top down** method. Meaning all new errors should be added to the bottom of the file. You can specify whether an error is formatted or backtraced through a decorator above a function name, where the formatted ones require a Span as an argument by default. The body takes any additional arguments you want provided to the function, the message, and the optional help message for the error. The additional arguments are just specified to implement traits to avoid as many type conversions in other Leo crates.
-- [Span](../../compiler/span/src/span.rs): Which contains the span object used throughout the other Leo crates (with the exception of the Input crate see more [below](#input)).
+- [Span](../compiler/span/src/span.rs): Which contains the span object used throughout the other Leo crates (with the exception of the Input crate see more [below](#input)).
 - [Traits](./src/common/traits.rs): Which contains the common traits in errors to make defining errors easier.
 
 ## Error Types

--- a/errors/README.md
+++ b/errors/README.md
@@ -22,7 +22,7 @@ The common section of this crate contains a few sub files:
 - [Backtraced Error](./src/common/backtraced.rs): Which contains the information needed to create a backtraceable error for Leo.
 - [Formatted Error](./src/common/formatted.rs): Which contains the information needed to create a formatted error for Leo.
 - [Macros](./src/common/macros.rs): Which contains the logic to make creating errors easy through a DSL. It also figures out the error codes for each error via a **top down** method. Meaning all new errors should be added to the bottom of the file. You can specify whether an error is formatted or backtraced through a decorator above a function name, where the formatted ones require a Span as an argument by default. The body takes any additional arguments you want provided to the function, the message, and the optional help message for the error. The additional arguments are just specified to implement traits to avoid as many type conversions in other Leo crates.
-- [Span](./src/common/span.rs): Which contains the span object used throughout the other Leo crates (with the exception of the Input crate see more [below](#input)).
+- [Span](../../compiler/span/src/span.rs): Which contains the span object used throughout the other Leo crates (with the exception of the Input crate see more [below](#input)).
 - [Traits](./src/common/traits.rs): Which contains the common traits in errors to make defining errors easier.
 
 ## Error Types


### PR DESCRIPTION
## Motivation

Replaced the outdated or broken link to `span.rs` with a correct relative path (`../../compiler/span/src/span.rs`) within the repository. This ensures that contributors can easily navigate to the Span implementation from the documentation, regardless of their local or remote environment.
