### PR TITLE
[Feature] Type inference for variables

### DIFF
--- a/compiler/ast/src/statement/definition/mod.rs
+++ b/compiler/ast/src/statement/definition/mod.rs
@@ -28,7 +28,7 @@ pub struct DefinitionStatement {
     /// The bindings / variable names to declare.
     pub place: DefinitionPlace,
     /// The types of the bindings, if specified, or inferred otherwise.
-    pub type_: Type,
+    pub type_: Option<Type>,
     /// An initializer value for the bindings.
     pub value: Expression,
     /// The span excluding the semicolon.
@@ -54,11 +54,10 @@ impl fmt::Display for DefinitionPlace {
 
 impl fmt::Display for DefinitionStatement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // For an Err type (as produced by many passes), don't write the type to reduce verbosity.
-        if let Type::Err = self.type_ {
-            write!(f, "let {} = {}", self.place, self.value)
-        } else {
-            write!(f, "let {}: {} = {}", self.place, self.type_, self.value)
+        match &self.type_ {
+            // For an Err type (as produced by many passes), don't write the type to reduce verbosity.
+            Some(Type::Err) | None => write!(f, "let {} = {}", self.place, self.value),
+            Some(ty) => write!(f, "let {}: {} = {}", self.place, ty, self.value),
         }
     }
 }

--- a/compiler/parser/src/parser/statement.rs
+++ b/compiler/parser/src/parser/statement.rs
@@ -250,8 +250,9 @@ impl<N: Network> ParserContext<'_, N> {
 
         // Parse variable name and type.
         let place = self.parse_definition_place()?;
-        self.expect(&Token::Colon)?;
-        let type_ = self.parse_type()?.0;
+
+        // The type annotation is optional
+        let type_ = if self.eat(&Token::Colon) { Some(self.parse_type()?.0) } else { None };
 
         self.expect(&Token::Assign)?;
         let value = self.parse_expression()?;

--- a/compiler/passes/src/common/assigner/mod.rs
+++ b/compiler/passes/src/common/assigner/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::{DefinitionPlace, DefinitionStatement, Expression, Identifier, NodeID, Statement, Type};
+use leo_ast::{DefinitionPlace, DefinitionStatement, Expression, Identifier, NodeID, Statement};
 use leo_span::Symbol;
 
 use std::{cell::RefCell, fmt::Display};
@@ -60,7 +60,7 @@ impl AssignerInner {
     fn simple_definition(&mut self, identifier: Identifier, value: Expression, id: NodeID) -> Statement {
         DefinitionStatement {
             place: DefinitionPlace::Single(identifier),
-            type_: Type::Err,
+            type_: None,
             value,
             span: Default::default(),
             id,

--- a/compiler/passes/src/destructuring/statement.rs
+++ b/compiler/passes/src/destructuring/statement.rs
@@ -178,7 +178,7 @@ impl StatementReconstructor for DestructuringVisitor<'_> {
                     // Make a definition for each.
                     let stmt = DefinitionStatement {
                         place: Single(*identifier),
-                        type_: ty.clone(),
+                        type_: Some(ty.clone()),
                         value: Expression::Identifier(*rhs_identifier),
                         span: Default::default(),
                         id: self.state.node_builder.next_id(),
@@ -202,7 +202,7 @@ impl StatementReconstructor for DestructuringVisitor<'_> {
                     // Make a definition for each.
                     let stmt = DefinitionStatement {
                         place: Single(*identifier),
-                        type_: ty.clone(),
+                        type_: Some(ty.clone()),
                         value: expr,
                         span: Default::default(),
                         id: self.state.node_builder.next_id(),
@@ -243,7 +243,7 @@ impl StatementReconstructor for DestructuringVisitor<'_> {
                 for (identifier, expr) in identifiers.into_iter().zip_eq(tuple.elements) {
                     let stmt = DefinitionStatement {
                         place: Single(identifier),
-                        type_: Type::Err,
+                        type_: None,
                         value: expr,
                         span: Default::default(),
                         id: self.state.node_builder.next_id(),
@@ -261,7 +261,7 @@ impl StatementReconstructor for DestructuringVisitor<'_> {
                 for (identifier, rhs_identifier) in identifiers.into_iter().zip_eq(rhs_identifiers.iter()) {
                     let stmt = DefinitionStatement {
                         place: Single(identifier),
-                        type_: Type::Err,
+                        type_: None,
                         value: Expression::Identifier(*rhs_identifier),
                         span: Default::default(),
                         id: self.state.node_builder.next_id(),
@@ -276,7 +276,7 @@ impl StatementReconstructor for DestructuringVisitor<'_> {
             (m @ Multiple(..), value @ Expression::Call(..), Type::Tuple(..)) => {
                 // Just reconstruct the statement.
                 let stmt =
-                    DefinitionStatement { place: m, type_: Type::Err, value, span: definition.span, id: definition.id }
+                    DefinitionStatement { place: m, type_: None, value, span: definition.span, id: definition.id }
                         .into();
                 (stmt, statements)
             }
@@ -287,7 +287,7 @@ impl StatementReconstructor for DestructuringVisitor<'_> {
                 // This isn't a tuple. Just build the definition again.
                 let stmt = DefinitionStatement {
                     place: s,
-                    type_: Type::Err,
+                    type_: None,
                     value: rhs,
                     span: Default::default(),
                     id: definition.id,

--- a/compiler/passes/src/destructuring/visitor.rs
+++ b/compiler/passes/src/destructuring/visitor.rs
@@ -121,7 +121,7 @@ impl DestructuringVisitor<'_> {
 
         Statement::Definition(DefinitionStatement {
             place: DefinitionPlace::Multiple(new_identifiers),
-            type_: Type::Tuple(tuple_type.clone()),
+            type_: Some(Type::Tuple(tuple_type.clone())),
             value: expression,
             span: Default::default(),
             id: self.state.node_builder.next_id(),

--- a/compiler/passes/src/flattening/statement.rs
+++ b/compiler/passes/src/flattening/statement.rs
@@ -303,7 +303,7 @@ impl StatementReconstructor for FlatteningVisitor<'_> {
                 (
                     DefinitionStatement {
                         place: DefinitionPlace::Multiple(identifiers),
-                        type_: Type::Err,
+                        type_: None,
                         value,
                         span: Default::default(),
                         id: self.state.node_builder.next_id(),

--- a/compiler/passes/src/function_inlining/statement.rs
+++ b/compiler/passes/src/function_inlining/statement.rs
@@ -28,7 +28,6 @@ use leo_ast::{
     IterationStatement,
     Statement,
     StatementReconstructor,
-    Type,
 };
 
 impl StatementReconstructor for FunctionInliningVisitor<'_> {
@@ -79,7 +78,7 @@ impl StatementReconstructor for FunctionInliningVisitor<'_> {
                 for (identifier, rhs_value) in left.into_iter().zip(right.elements) {
                     let stmt = DefinitionStatement {
                         place: DefinitionPlace::Single(identifier),
-                        type_: Type::Err,
+                        type_: None,
                         value: rhs_value,
                         span: Default::default(),
                         id: self.state.node_builder.next_id(),

--- a/compiler/passes/src/static_single_assignment/statement.rs
+++ b/compiler/passes/src/static_single_assignment/statement.rs
@@ -36,7 +36,6 @@ use leo_ast::{
     Statement,
     StatementConsumer,
     TernaryExpression,
-    Type,
 };
 use leo_span::Symbol;
 
@@ -283,7 +282,7 @@ impl StatementConsumer for SsaFormingVisitor<'_> {
                 };
 
                 // Create the definition.
-                let definition = DefinitionStatement { place, type_: Type::Err, value, ..definition }.into();
+                let definition = DefinitionStatement { place, type_: None, value, ..definition }.into();
 
                 statements.push(definition);
             }

--- a/compiler/passes/src/type_checking/expression.rs
+++ b/compiler/passes/src/type_checking/expression.rs
@@ -650,11 +650,19 @@ impl ExpressionVisitor for TypeCheckingVisitor<'_> {
         // Async functions return a single future.
         let mut ret = if func.variant == Variant::AsyncFunction {
             // Type check after resolving the input types.
-            if let Some(Type::Future(_)) = expected {
-                Type::Future(FutureType::new(Vec::new(), Some(Location::new(callee_program, ident.name)), false))
-            } else {
-                self.emit_err(TypeCheckerError::return_type_of_finalize_function_is_future(input.span));
-                Type::Unit
+            let actual =
+                Type::Future(FutureType::new(Vec::new(), Some(Location::new(callee_program, ident.name)), false));
+            match expected {
+                Some(Type::Future(_)) | None => {
+                    // If the expected type is a `Future` or if it's not set, then just return the
+                    // actual type of the future from the expression itself
+                    actual
+                }
+                Some(_) => {
+                    // Otherwise, error out. There is a mismatch in types.
+                    self.maybe_assert_type(&actual, expected, input.span());
+                    Type::Unit
+                }
             }
         } else if func.variant == Variant::AsyncTransition {
             // Fully infer future type.
@@ -1041,30 +1049,55 @@ impl ExpressionVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_tuple(&mut self, input: &TupleExpression, expected: &Self::AdditionalInput) -> Self::Output {
-        // Check the expected tuple types if they are known.
-        let Some(Type::Tuple(expected_types)) = expected else {
-            self.emit_err(TypeCheckerError::invalid_tuple(input.span()));
-            return Type::Err;
-        };
+        if let Some(expected) = expected {
+            if let Type::Tuple(expected_types) = expected {
+                // If the expected type is a tuple, then ensure it's compatible with `input`
 
-        // Check actual length is equal to expected length.
-        if expected_types.length() != input.elements.len() {
-            self.emit_err(TypeCheckerError::incorrect_tuple_length(
-                expected_types.length(),
-                input.elements.len(),
-                input.span(),
-            ));
-        }
+                // First, make sure that the number of tuple elements is correct
+                if expected_types.length() != input.elements.len() {
+                    self.emit_err(TypeCheckerError::incorrect_tuple_length(
+                        expected_types.length(),
+                        input.elements.len(),
+                        input.span(),
+                    ));
+                }
 
-        for (expr, expected) in input.elements.iter().zip(expected_types.elements().iter()) {
-            if matches!(expr, Expression::Tuple(_)) {
-                self.emit_err(TypeCheckerError::nested_tuple_expression(expr.span()))
+                // Now make sure that none of the tuple elements is a tuple
+                input.elements.iter().zip(expected_types.elements()).for_each(|(expr, expected_el_ty)| {
+                    if matches!(expr, Expression::Tuple(_)) {
+                        self.emit_err(TypeCheckerError::nested_tuple_expression(expr.span()));
+                    }
+                    self.visit_expression(expr, &Some(expected_el_ty.clone()));
+                });
+
+                // Just return the expected type since we proved it's correct
+                expected.clone()
+            } else {
+                // If the expected type is not a tuple, then we just error out
+
+                // This is the expected type of the tuple based on its individual fields
+                let inferred_type = Type::Tuple(TupleType::new(
+                    input.elements.iter().map(|field| self.visit_expression(field, &None)).collect::<Vec<_>>(),
+                ));
+                self.emit_err(TypeCheckerError::type_should_be2(inferred_type.clone(), expected, input.span()));
+
+                // Recover with the expected type anyways
+                expected.clone()
             }
+        } else {
+            // If no `expected` type is provided, then we analyze the tuple itself and infer its type
 
-            self.visit_expression(expr, &Some(expected.clone()));
+            // We still need to check that none of the tuple elements is a tuple
+            input.elements.iter().for_each(|expr| {
+                if matches!(expr, Expression::Tuple(_)) {
+                    self.emit_err(TypeCheckerError::nested_tuple_expression(expr.span()));
+                }
+            });
+
+            Type::Tuple(TupleType::new(
+                input.elements.iter().map(|field| self.visit_expression(field, &None)).collect::<Vec<_>>(),
+            ))
         }
-
-        Type::Tuple(expected_types.clone())
     }
 
     fn visit_unary(&mut self, input: &UnaryExpression, destination: &Self::AdditionalInput) -> Self::Output {

--- a/compiler/passes/src/write_transforming/statement.rs
+++ b/compiler/passes/src/write_transforming/statement.rs
@@ -67,7 +67,7 @@ impl WriteTransformingVisitor<'_> {
                 self.state.type_table.insert(access.id(), self.state.type_table.get(&member.id()).unwrap().clone());
                 let def = DefinitionStatement {
                     place: DefinitionPlace::Single(member),
-                    type_: Type::Err,
+                    type_: None,
                     value: access.into(),
                     span: Default::default(),
                     id: self.state.node_builder.next_id(),
@@ -88,7 +88,7 @@ impl WriteTransformingVisitor<'_> {
                 self.state.type_table.insert(access.id(), self.state.type_table.get(&member.id()).unwrap().clone());
                 let def = DefinitionStatement {
                     place: DefinitionPlace::Single(member),
-                    type_: Type::Err,
+                    type_: None,
                     value: access.into(),
                     span: Default::default(),
                     id: self.state.node_builder.next_id(),

--- a/tests/expectations/compiler/constants/const_type_error_fail.out
+++ b/tests/expectations/compiler/constants/const_type_error_fail.out
@@ -1,7 +1,5 @@
-Error [ETYC0372023]: Tuples must be explicitly typed in Leo
+Error [ETYC0372117]: Expected u8 but type `((u8, u8), u8)` was found.
     --> compiler-test:6:23
      |
    6 |         const B: u8 = ((1u8,1u8),1u8);
      |                       ^^^^^^^^^^^^^^^
-     |
-     = The function definition must match the function return statement

--- a/tests/expectations/compiler/field/no_space_between_literal.out
+++ b/tests/expectations/compiler/field/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:13
+Error [EPAR0370004]: Unexpected white space between terms 1 and field
+    --> compiler-test:4:16
      |
    4 |       let f = 1 field;
-     |             ^

--- a/tests/expectations/compiler/finalize/unknown_mapping_operation_fail.out
+++ b/tests/expectations/compiler/finalize/unknown_mapping_operation_fail.out
@@ -1,4 +1,4 @@
-Error [ETYC0372107]: The output of an async function must be assigned to a `Future` type..
+Error [ETYC0372117]: Expected type `()` but type `Future<Fn()>` was found.
     --> compiler-test:7:17
      |
    7 |          return finalize_mint_public(receiver, amount);

--- a/tests/expectations/compiler/function/scope_fail.out
+++ b/tests/expectations/compiler/function/scope_fail.out
@@ -1,5 +1,5 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:9:22
+Error [ETYC0372005]: Unknown variable `myGlobal`
+    --> compiler-test:5:16
      |
-   9 |         let myGlobal = 42field;
-     |                      ^
+   5 |         return myGlobal;
+     |                ^^^^^^^^

--- a/tests/expectations/compiler/function/shadow_parameter_fail.out
+++ b/tests/expectations/compiler/function/shadow_parameter_fail.out
@@ -1,5 +1,5 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:16
+Error [EAST0372009]: variable `hi` shadowed by
+    --> compiler-test:4:13
      |
    4 |         let hi = 2u8;
-     |                ^
+     |             ^^

--- a/tests/expectations/compiler/integers/i128/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/i128/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and i128
+    --> compiler-test:4:18
      |
    4 |         let i = 1 i128;
-     |               ^

--- a/tests/expectations/compiler/integers/i16/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/i16/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and i16
+    --> compiler-test:4:18
      |
    4 |         let i = 1 i16;
-     |               ^

--- a/tests/expectations/compiler/integers/i32/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/i32/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and i32
+    --> compiler-test:4:18
      |
    4 |         let i = 1 i32;
-     |               ^

--- a/tests/expectations/compiler/integers/i64/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/i64/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and i64
+    --> compiler-test:4:18
      |
    4 |         let i = 1 i64;
-     |               ^

--- a/tests/expectations/compiler/integers/i8/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/i8/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and i8
+    --> compiler-test:4:18
      |
    4 |         let i = 1 i8;
-     |               ^

--- a/tests/expectations/compiler/integers/u128/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/u128/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and u128
+    --> compiler-test:4:18
      |
    4 |         let i = 1 u128;
-     |               ^

--- a/tests/expectations/compiler/integers/u16/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/u16/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and u16
+    --> compiler-test:4:18
      |
    4 |         let i = 1 u16;
-     |               ^

--- a/tests/expectations/compiler/integers/u32/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/u32/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and u32
+    --> compiler-test:4:18
      |
    4 |         let i = 1 u32;
-     |               ^

--- a/tests/expectations/compiler/integers/u64/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/u64/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and u64
+    --> compiler-test:4:18
      |
    4 |         let i = 1 u64;
-     |               ^

--- a/tests/expectations/compiler/integers/u8/no_space_between_literal.out
+++ b/tests/expectations/compiler/integers/u8/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:15
+Error [EPAR0370004]: Unexpected white space between terms 1 and u8
+    --> compiler-test:4:18
      |
    4 |         let i = 1 u8;
-     |               ^

--- a/tests/expectations/compiler/multibyte/multibyte_fail.out
+++ b/tests/expectations/compiler/multibyte/multibyte_fail.out
@@ -1,5 +1,5 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:30:29
+Error [EPAR0370005]: expected 'address', 'bool', 'field', 'Future', 'group', 'scalar', 'signature', 'string', 'i8', 'i16', 'i32', 'i64', 'i128', 'u8', 'u16', 'u32', 'u64', 'u128' -- found '='
+    --> compiler-test:30:30
      |
-  30 |                    let swap = arr[j];
-     |                             ^
+  30 |                    let swap: = arr[j];
+     |                              ^

--- a/tests/expectations/compiler/scalar/no_space_between_literal.out
+++ b/tests/expectations/compiler/scalar/no_space_between_literal.out
@@ -1,5 +1,4 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:4:13
+Error [EPAR0370004]: Unexpected white space between terms 1 and scalar
+    --> compiler-test:4:16
      |
    4 |       let f = 1 scalar;
-     |             ^

--- a/tests/expectations/compiler/structs/member_variable_fail.out
+++ b/tests/expectations/compiler/structs/member_variable_fail.out
@@ -1,5 +1,7 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> compiler-test:9:17
+Error [ETYC0372018]: Variable y is not a member of struct Foo {
+    x: u32,
+}.
+    --> compiler-test:9:21
      |
    9 |         let err = a.y;
-     |                 ^
+     |                     ^

--- a/tests/expectations/compiler/type_inference/bad_tuples_fail.out
+++ b/tests/expectations/compiler/type_inference/bad_tuples_fail.out
@@ -1,0 +1,45 @@
+Error [ETYC0372052]: A tuple expression cannot contain another tuple expression.
+    --> compiler-test:4:22
+     |
+   4 |         let t0 = (x, (y, z));
+     |                      ^^^^^^
+Error [ETYC0372117]: Expected u32 but type `(u32, u32)` was found.
+    --> compiler-test:5:23
+     |
+   5 |         let t1: u32 = (x, y);
+     |                       ^^^^^^
+Error [ETYC0372022]: Expected a tuple of length `2` found length `3`
+    --> compiler-test:6:30
+     |
+   6 |         let t2: (u32, u32) = (x, y, z);
+     |                              ^^^^^^^^^
+Error [ETYC0372049]: A tuple type cannot contain a tuple.
+    --> compiler-test:7:9
+     |
+   7 |         let t3: (u32, (u32, u32)) = (x, (y, z));
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372052]: A tuple expression cannot contain another tuple expression.
+    --> compiler-test:7:41
+     |
+   7 |         let t3: (u32, (u32, u32)) = (x, (y, z));
+     |                                         ^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `u32` was found.
+    --> compiler-test:8:33
+     |
+   8 |         let t4: (u32, u8) = (x, y);
+     |                                 ^
+Error [ETYC0372072]: Expected a tuple with 3 elements, found one with 2 elements
+    --> compiler-test:9:9
+     |
+   9 |         let (a, b) = (x, y, z);
+     |         ^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372117]: Expected u32 but type `(u32, u32)` was found.
+    --> compiler-test:10:27
+     |
+  10 |         let (a, b): u32 = (x, y);
+     |                           ^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `u32` was found.
+    --> compiler-test:11:37
+     |
+  11 |         let (a, b): (u32, u8) = (x, y);
+     |                                     ^

--- a/tests/expectations/compiler/type_inference/basic_inference.out
+++ b/tests/expectations/compiler/type_inference/basic_inference.out
@@ -1,0 +1,24 @@
+program foo.aleo;
+
+struct S:
+    x as u32;
+    y as u32;
+
+function main:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as address.private;
+    input r3 as [u32; 4u32].private;
+    cast r0 r1 into r4 as S;
+    cast r4.x 42u32 into r5 as S;
+    add r0 1u32 into r6;
+    add r1 2u32 into r7;
+    mul r6 r6 into r8;
+    output r4 as S.private;
+    output r5 as S.private;
+    output 42u64 as u64.private;
+    output r6 as u32.private;
+    output r7 as u32.private;
+    output true as boolean.private;
+    output r8 as u32.private;
+    output r3[3u32] as u32.private;

--- a/tests/expectations/compiler/type_inference/futures.out
+++ b/tests/expectations/compiler/type_inference/futures.out
@@ -1,0 +1,38 @@
+program child.aleo;
+
+function foo:
+    async foo into r0;
+    output r0 as child.aleo/foo.future;
+
+finalize foo:
+    assert.eq true true;
+
+function bar:
+    async bar into r0;
+    output r0 as child.aleo/bar.future;
+
+finalize bar:
+    assert.eq true true;
+// --- Next Program --- //
+import child.aleo;
+program type_inference.aleo;
+
+function t1:
+    call child.aleo/foo into r0;
+    async t1 r0 into r1;
+    output 42u64 as u64.private;
+    output r1 as type_inference.aleo/t1.future;
+
+finalize t1:
+    input r0 as child.aleo/foo.future;
+    await r0;
+
+function t2:
+    call child.aleo/bar into r0;
+    async t2 r0 into r1;
+    output 99u64 as u64.private;
+    output r1 as type_inference.aleo/t2.future;
+
+finalize t2:
+    input r0 as child.aleo/bar.future;
+    await r0;

--- a/tests/expectations/compiler/type_inference/futures_fail.out
+++ b/tests/expectations/compiler/type_inference/futures_fail.out
@@ -1,0 +1,64 @@
+Error [ETYC0372003]: Expected type `u32` but type `Future<Fn()>` was found
+    --> compiler-test:7:22
+     |
+   7 |         let f: u32 = child.aleo/foo();
+     |                      ^^^^^^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `Future<Fn()>` was found.
+    --> compiler-test:8:21
+     |
+   8 |         let r: u8 = foo(f);
+     |                     ^^^^^^
+Error [ETYC0372117]: Expected type `Future<Fn()>` but type `u32` was found.
+    --> compiler-test:8:25
+     |
+   8 |         let r: u8 = foo(f);
+     |                         ^
+Error [ETYC0372103]: Unknown future consumed: `f`
+    --> compiler-test:8:25
+     |
+   8 |         let r: u8 = foo(f);
+     |                         ^
+     |
+     = Make sure the future is defined and consumed exactly once.
+Error [ETYC0372003]: Expected type `u8` but type `Future<Fn(u32)>` was found
+    --> compiler-test:8:21
+     |
+   8 |         let r: u8 = foo(f);
+     |                     ^^^^^^
+Error [ETYC0372117]: Expected type `Future<Fn(u32)>` but type `u8` was found.
+    --> compiler-test:9:24
+     |
+   9 |         return (42u64, r);
+     |                        ^
+Error [ETYC0372003]: Expected type `(u8, u8)` but type `Future<Fn()>` was found
+    --> compiler-test:13:27
+     |
+  13 |         let f: (u8, u8) = child.aleo/bar();
+     |                           ^^^^^^^^^^^^^^^^
+Error [ETYC0372117]: Expected type `bool` but type `Future<Fn()>` was found.
+    --> compiler-test:14:23
+     |
+  14 |         let r: bool = foo(f);
+     |                       ^^^^^^
+Error [ETYC0372117]: Expected type `Future<Fn()>` but type `(u8, u8)` was found.
+    --> compiler-test:14:27
+     |
+  14 |         let r: bool = foo(f);
+     |                           ^
+Error [ETYC0372103]: Unknown future consumed: `f`
+    --> compiler-test:14:27
+     |
+  14 |         let r: bool = foo(f);
+     |                           ^
+     |
+     = Make sure the future is defined and consumed exactly once.
+Error [ETYC0372003]: Expected type `bool` but type `Future<Fn((u8, u8))>` was found
+    --> compiler-test:14:23
+     |
+  14 |         let r: bool = foo(f);
+     |                       ^^^^^^
+Error [ETYC0372117]: Expected type `Future<Fn((u8, u8))>` but type `bool` was found.
+    --> compiler-test:15:24
+     |
+  15 |         return (99u64, r);
+     |                        ^

--- a/tests/expectations/parser-statement/statement/conditional_fail.out
+++ b/tests/expectations/parser-statement/statement/conditional_fail.out
@@ -1,5 +1,5 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> test_0:1:23
+Error [EPAR0370017]: Could not parse the implicit value: 2.
+    --> test_0:1:25
      |
    1 | if true {} else let x = 2;
-     |                       ^
+     |                         ^

--- a/tests/expectations/parser-statement/statement/definition_fail.out
+++ b/tests/expectations/parser-statement/statement/definition_fail.out
@@ -1,103 +1,74 @@
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_0:1:9
-     |
-   1 | let mut x = expr;
-     |         ^
-Error [EPAR0370005]: expected : -- found 'x'
+{
+  "Definition": {
+    "place": {
+      "Single": {
+        "name": "x",
+        "span": {
+          "lo": 4,
+          "hi": 5
+        },
+        "id": 0
+      }
+    },
+    "type_": null,
+    "value": {
+      "Identifier": {
+        "name": "expr",
+        "span": {
+          "lo": 8,
+          "hi": 12
+        },
+        "id": 1
+      }
+    },
+    "span": {
+      "lo": 0,
+      "hi": 12
+    },
+    "id": 2
+  }
+}
+
+Error [EPAR0370029]: A tuple expression must have at least two elements.
     --> test_1:1:9
      |
-   1 | let mut x = ();
+   1 | let x = ();
+     |         ^^
+Error [EPAR0370005]: expected : -- found '='
+    --> test_5:1:9
+     |
+   1 | const x = expr;
      |         ^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_2:1:9
+Error [EPAR0370005]: expected : -- found '='
+    --> test_6:1:9
      |
-   1 | let mut x = x+y;
+   1 | const x = ();
      |         ^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_3:1:9
+Error [EPAR0370005]: expected : -- found '='
+    --> test_7:1:9
      |
-   1 | let mut x = (x,y);
+   1 | const x = x+y;
      |         ^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_4:1:9
+Error [EPAR0370005]: expected : -- found '='
+    --> test_8:1:9
      |
-   1 | let mut x = x();
+   1 | const x = (x,y);
      |         ^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_5:1:1
+Error [EPAR0370005]: expected : -- found '='
+    --> test_9:1:9
      |
-   1 | constant mut x = expr;
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_6:1:1
-     |
-   1 | constant mut x = ();
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_7:1:1
-     |
-   1 | constant mut x = x+y;
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_8:1:1
-     |
-   1 | constant mut x = (x,y);
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_9:1:1
-     |
-   1 | constant mut x = x();
-     | ^^^^^^^^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_10:1:9
-     |
-   1 | let mut x: u32 = expr;
+   1 | const x = x();
      |         ^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_11:1:9
+Error [EPAR0370029]: A tuple expression must have at least two elements.
+    --> test_11:1:14
      |
-   1 | let mut x: u32 = ();
-     |         ^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_12:1:9
+   1 | let x: u32 = ();
+     |              ^^
+Error [EPAR0370029]: A tuple expression must have at least two elements.
+    --> test_16:1:16
      |
-   1 | let mut x: u32 = x+y;
-     |         ^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_13:1:9
-     |
-   1 | let mut x: u32 = (x,y);
-     |         ^
-Error [EPAR0370005]: expected : -- found 'x'
-    --> test_14:1:9
-     |
-   1 | let mut x: u32 = x();
-     |         ^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_15:1:1
-     |
-   1 | constant mut x: u32 = expr;
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_16:1:1
-     |
-   1 | constant mut x: u32 = ();
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_17:1:1
-     |
-   1 | constant mut x: u32 = x+y;
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_18:1:1
-     |
-   1 | constant mut x: u32 = (x,y);
-     | ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_19:1:1
-     |
-   1 | constant mut x: u32 = x();
-     | ^^^^^^^^
+   1 | const x: u32 = ();
+     |                ^^
 Error [EPAR0370045]: Expected an identifier.
     --> test_20:1:10
      |
@@ -118,22 +89,22 @@ Error [EPAR0370005]: expected integer literal -- found '('
      |
    1 | let x: [u8; (2,,)] = [[0,0], [0,0]];
      |             ^
-Error [EPAR0370005]: expected 'address', 'bool', 'field', 'Future', 'group', 'scalar', 'signature', 'string', 'i8', 'i16', 'i32', 'i64', 'i128', 'u8', 'u16', 'u32', 'u64', 'u128' -- found 'constant'
+Error [EPAR0370005]: expected 'address', 'bool', 'field', 'Future', 'group', 'scalar', 'signature', 'string', 'i8', 'i16', 'i32', 'i64', 'i128', 'u8', 'u16', 'u32', 'u64', 'u128' -- found 'const'
     --> test_24:1:8
      |
-   1 | let x: constant = expr;
-     |        ^^^^^^^^
-Error [EPAR0370009]: unexpected string: expected 'expression', found 'constant'
-    --> test_25:1:1
+   1 | let x: const = expr;
+     |        ^^^^^
+Error [EPAR0370005]: expected 'address', 'bool', 'field', 'Future', 'group', 'scalar', 'signature', 'string', 'i8', 'i16', 'i32', 'i64', 'i128', 'u8', 'u16', 'u32', 'u64', 'u128' -- found 'let'
+    --> test_25:1:10
      |
-   1 | constant x: let = expr;
-     | ^^^^^^^^
+   1 | const x: let = expr;
+     |          ^^^
 Error [EPAR0370005]: expected ( -- found '<eof>'
     --> test_26:1:1
      |
    1 | let
      | ^^^
-Error [EPAR0370005]: expected : -- found '<eof>'
+Error [EPAR0370005]: expected = -- found '<eof>'
     --> test_27:1:5
      |
    1 | let x
@@ -143,11 +114,11 @@ Error [EPAR0370005]: expected 'address', 'bool', 'field', 'Future', 'group', 'sc
      |
    1 | let x:
      |      ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_29:1:7
+Error [EPAR0370005]: expected ) -- found ']'
+    --> test_29:1:14
      |
    1 | let x = (a, y]);
-     |       ^
+     |              ^
 Error [EPAR0370005]: expected ( -- found '='
     --> test_30:1:5
      |
@@ -158,7 +129,7 @@ Error [EPAR0370005]: expected ( -- found ';'
      |
    1 | let;
      |    ^
-Error [EPAR0370005]: expected : -- found '1'
+Error [EPAR0370005]: expected = -- found '1'
     --> test_32:1:7
      |
    1 | let x 1u8;
@@ -200,16 +171,16 @@ Error [EPAR0370009]: unexpected string: expected 'expression', found ']'
      |               ^
 Error [EPAR0370016]: Could not lex the following content: `🦀:`.
 
-Error [EPAR0370005]: expected : -- found '='
-    --> test_41:1:9
+Error [EPAR0370009]: unexpected string: expected 'expression', found '..'
+    --> test_41:1:11
      |
    1 | let (x) = ...;
-     |         ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_42:1:10
+     |           ^^
+Error [EPAR0370009]: unexpected string: expected 'expression', found '..'
+    --> test_42:1:12
      |
    1 | let (x,) = ...;
-     |          ^
+     |            ^^
 Error [EPAR0370005]: expected ( -- found '_'
     --> test_43:1:5
      |

--- a/tests/expectations/parser-statement/unreachable/math_op_fail.out
+++ b/tests/expectations/parser-statement/unreachable/math_op_fail.out
@@ -1,188 +1,183 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> test_0:1:7
+Error [EPAR0370005]: expected <eof> -- found 'b'
+    --> test_0:1:13
      |
    1 | let x = a ; b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_1:1:7
+     |             ^
+Error [EPAR0370005]: expected ; -- found 'import'
+    --> test_1:1:11
      |
    1 | let x = a import b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_2:1:7
+     |           ^^^^^^
+Error [EPAR0370005]: expected ; -- found ','
+    --> test_2:1:11
      |
    1 | let x = a , b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_3:1:7
+     |           ^
+Error [EPAR0370005]: expected ] -- found ';'
+    --> test_3:1:14
      |
    1 | let x = a [ b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_4:1:7
+     |              ^
+Error [EPAR0370005]: expected ; -- found ']'
+    --> test_4:1:11
      |
    1 | let x = a ] b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_5:1:7
+     |           ^
+Error [EPAR0370005]: expected } -- found ';'
+    --> test_5:1:14
      |
    1 | let x = a { b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_6:1:7
+     |              ^
+Error [EPAR0370005]: expected ; -- found '}'
+    --> test_6:1:11
      |
    1 | let x = a } b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_7:1:7
+     |           ^
+Error [EPAR0370005]: expected ) -- found ';'
+    --> test_7:1:14
      |
    1 | let x = a ( b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_8:1:7
+     |              ^
+Error [EPAR0370005]: expected ; -- found ')'
+    --> test_8:1:11
      |
    1 | let x = a ) b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_9:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found ':'
+    --> test_9:1:11
      |
    1 | let x = a : b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_10:1:7
+     |           ^
+Error [EPAR0370005]: expected : -- found ';'
+    --> test_10:1:14
      |
    1 | let x = a ? b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_11:1:7
+     |              ^
+Error [EPAR0370005]: expected ; -- found '_'
+    --> test_11:1:11
      |
    1 | let x = a _ b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_12:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found '='
+    --> test_12:1:11
      |
    1 | let x = a = b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_13:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found '!'
+    --> test_13:1:11
      |
    1 | let x = a ! b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_14:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found '..'
+    --> test_14:1:11
      |
    1 | let x = a .. b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_15:1:7
+     |           ^^
+Error [EPAR0370005]: expected ; -- found 'const'
+    --> test_15:1:11
      |
    1 | let x = a const b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_16:1:7
+     |           ^^^^^
+Error [EPAR0370005]: expected ; -- found 'let'
+    --> test_16:1:11
      |
    1 | let x = a let b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_17:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'for'
+    --> test_17:1:11
      |
    1 | let x = a for b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_18:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'if'
+    --> test_18:1:11
      |
    1 | let x = a if b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_19:1:7
+     |           ^^
+Error [EPAR0370005]: expected ; -- found 'else'
+    --> test_19:1:11
      |
    1 | let x = a else b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_20:1:7
+     |           ^^^^
+Error [EPAR0370005]: expected ; -- found 'i8'
+    --> test_20:1:11
      |
    1 | let x = a i8 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_21:1:7
+     |           ^^
+Error [EPAR0370005]: expected ; -- found 'i16'
+    --> test_21:1:11
      |
    1 | let x = a i16 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_22:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'i32'
+    --> test_22:1:11
      |
    1 | let x = a i32 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_23:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'i64'
+    --> test_23:1:11
      |
    1 | let x = a i64 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_24:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'i128'
+    --> test_24:1:11
      |
    1 | let x = a i128 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_25:1:7
+     |           ^^^^
+Error [EPAR0370005]: expected ; -- found 'u8'
+    --> test_25:1:11
      |
    1 | let x = a u8 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_26:1:7
+     |           ^^
+Error [EPAR0370005]: expected ; -- found 'u16'
+    --> test_26:1:11
      |
    1 | let x = a u16 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_27:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'u32'
+    --> test_27:1:11
      |
    1 | let x = a u32 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_28:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'u64'
+    --> test_28:1:11
      |
    1 | let x = a u64 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_29:1:7
+     |           ^^^
+Error [EPAR0370005]: expected ; -- found 'u128'
+    --> test_29:1:11
      |
    1 | let x = a u128 b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_30:1:7
-     |
-   1 | let x = a & b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_31:1:7
+     |           ^^^^
+Error [EPAR0370005]: expected ; -- found 'return'
+    --> test_31:1:11
      |
    1 | let x = a return b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_32:1:7
+     |           ^^^^^^
+Error [EPAR0370005]: expected ; -- found 'self'
+    --> test_32:1:11
      |
    1 | let x = a self b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_33:1:7
+     |           ^^^^
+Error [EPAR0370005]: expected ; -- found 'Self'
+    --> test_33:1:11
      |
    1 | let x = a Self b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_34:1:7
+     |           ^^^^
+Error [EPAR0370005]: expected ; -- found 'true'
+    --> test_34:1:11
      |
    1 | let x = a true b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_35:1:7
+     |           ^^^^
+Error [EPAR0370005]: expected ; -- found 'false'
+    --> test_35:1:11
      |
    1 | let x = a false b;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_36:1:7
+     |           ^^^^^
+Error [EPAR0370005]: expected ; -- found '0'
+    --> test_36:1:11
      |
    1 | let x = a 0 b;
-     |       ^
+     |           ^
 Error [EPAR0370005]: expected <eof> -- found '='
     --> test_37:1:3
      |

--- a/tests/expectations/parser-statement/unreachable/postfix_fail.out
+++ b/tests/expectations/parser-statement/unreachable/postfix_fail.out
@@ -1,100 +1,100 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> test_0:1:7
+Error [EPAR0370005]: expected <eof> -- found ';'
+    --> test_0:1:11
      |
    1 | let x = a;;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_1:1:7
+     |           ^
+Error [EPAR0370009]: unexpected string: expected 'identifier', found ';'
+    --> test_1:1:11
      |
    1 | let x = a.;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_2:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found ','
+    --> test_2:1:10
      |
    1 | let x = a,;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_3:1:7
+     |          ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_3:1:11
      |
    1 | let x = a[;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_4:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found ']'
+    --> test_4:1:10
      |
    1 | let x = a];
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_5:1:7
+     |          ^
+Error [EPAR0370009]: unexpected string: expected 'identifier', found ';'
+    --> test_5:1:11
      |
    1 | let x = a{;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_6:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found '}'
+    --> test_6:1:10
      |
    1 | let x = a};
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_7:1:7
+     |          ^
+Error [EPAR0370005]: expected ; -- found ')'
+    --> test_7:1:10
      |
    1 | let x = a);
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_8:1:7
+     |          ^
+Error [EPAR0370005]: expected ; -- found ':'
+    --> test_8:1:10
      |
    1 | let x = a:;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_9:1:7
+     |          ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_9:1:11
      |
    1 | let x = a?;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_10:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found '='
+    --> test_10:1:10
      |
    1 | let x = a=;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_11:1:7
+     |          ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_11:1:12
      |
    1 | let x = a==;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_12:1:7
+     |            ^
+Error [EPAR0370005]: expected ; -- found '!'
+    --> test_12:1:10
      |
    1 | let x = a!;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_13:1:7
+     |          ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_13:1:12
      |
    1 | let x = a!=;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_14:1:7
+     |            ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_14:1:11
      |
    1 | let x = a>;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_15:1:7
+     |           ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_15:1:12
      |
    1 | let x = a>=;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_16:1:7
+     |            ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_16:1:11
      |
    1 | let x = a<;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_17:1:7
+     |           ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_17:1:12
      |
    1 | let x = a<=;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_18:1:7
+     |            ^
+Error [EPAR0370009]: unexpected string: expected 'expression', found ';'
+    --> test_18:1:11
      |
    1 | let x = a>;
-     |       ^
-Error [EPAR0370005]: expected : -- found '='
-    --> test_19:1:7
+     |           ^
+Error [EPAR0370005]: expected ; -- found '..'
+    --> test_19:1:10
      |
    1 | let x = a..;
-     |       ^
+     |          ^^

--- a/tests/expectations/parser/program/hex_eof.out
+++ b/tests/expectations/parser/program/hex_eof.out
@@ -1,5 +1,5 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> test:3:29
+Error [EPAR0370017]: Could not parse the implicit value: 0x.
+    --> test:3:31
      |
    3 |     function main() { let a = 0x}
-     |                             ^
+     |                               ^^

--- a/tests/expectations/parser/program/pipe_eof.out
+++ b/tests/expectations/parser/program/pipe_eof.out
@@ -1,5 +1,5 @@
-Error [EPAR0370005]: expected : -- found '='
-    --> test:4:15
+Error [EPAR0370005]: expected 'const', 'struct', 'record', 'mapping', '@', 'async', 'function', 'transition', 'inline', 'script', '}' -- found '|'
+    --> test:6:5
      |
-   4 |         let x = 1u8;
-     |               ^
+   6 |     |}
+     |     ^

--- a/tests/expectations/parser/statement/let_mut_recover.out
+++ b/tests/expectations/parser/statement/let_mut_recover.out
@@ -1,4 +1,4 @@
-Error [EPAR0370005]: expected : -- found 'x'
+Error [EPAR0370005]: expected = -- found 'x'
     --> test:4:17
      |
    4 |         let mut x = 0;

--- a/tests/tests/compiler/function/scope_fail.leo
+++ b/tests/tests/compiler/function/scope_fail.leo
@@ -1,13 +1,13 @@
 
 program test.aleo {
 
-    function foo() -> field {
+    inline foo(x: u32) -> field {
         return myGlobal;
     }
 
-    function main() -> field {
+    transition main() -> field {
         let myGlobal = 42field;
-        let err = foo();
+        let err = foo(3u32);
 
         return err;
     }

--- a/tests/tests/compiler/function/shadow_parameter_fail.leo
+++ b/tests/tests/compiler/function/shadow_parameter_fail.leo
@@ -1,10 +1,10 @@
 
 program test.aleo {
-    function tester(hi: u8) -> u8 {
+    transition tester(hi: u8) -> u8 {
         let hi = 2u8;
         return hi;
     }
 
-    function main (y: bool) -> bool {
+    transition main(y: bool) -> bool {
         return y;
     }}

--- a/tests/tests/compiler/multibyte/multibyte_fail.leo
+++ b/tests/tests/compiler/multibyte/multibyte_fail.leo
@@ -27,7 +27,7 @@ program bubblesort.aleo {
            for j: u8 in 0u8..7u8-i {
                // Move the smaller elements forward
                if arr[j+1u8] < arr[j] {
-                   let swap = arr[j];
+                   let swap: = arr[j];
                    // let swap = arr[j];
                    arr[j] = arr[j+1u8];
                    arr[j+1u8] = swap;

--- a/tests/tests/compiler/structs/member_variable_fail.leo
+++ b/tests/tests/compiler/structs/member_variable_fail.leo
@@ -4,8 +4,8 @@ program test.aleo {
         x: u32,
     }
 
-    function main() {
-        let a: foo = Foo { x: 1u32 };
+    transition main() {
+        let a: Foo = Foo { x: 1u32 };
         let err = a.y;
     }
 }

--- a/tests/tests/compiler/type_inference/bad_tuples_fail.leo
+++ b/tests/tests/compiler/type_inference/bad_tuples_fail.leo
@@ -1,0 +1,13 @@
+program foo.aleo {
+    transition bad(x: u32, y: u32, z: u32) {
+        // All of these definitions are bad
+        let t0 = (x, (y, z));
+        let t1: u32 = (x, y);
+        let t2: (u32, u32) = (x, y, z);
+        let t3: (u32, (u32, u32)) = (x, (y, z));
+        let t4: (u32, u8) = (x, y);
+        let (a, b) = (x, y, z);
+        let (a, b): u32 = (x, y);
+        let (a, b): (u32, u8) = (x, y);
+    }
+}

--- a/tests/tests/compiler/type_inference/basic_inference.leo
+++ b/tests/tests/compiler/type_inference/basic_inference.leo
@@ -1,0 +1,29 @@
+program foo.aleo {
+    struct S {
+        x: u32,
+        y: u32,
+    }
+
+    record R {
+        owner: address,
+        v: u64
+    }
+    
+    transition main(x: u32, y: u32, addr: address, arr: [u32; 4]) 
+        -> (S, S, u64, u32, u32, bool, u32, u32) {
+        let s1 = S { x, y };
+        let s2: S = s1;
+        let s3 = s1;
+        s3.y = 42u32;
+        let t = (s2, s3, 42u64);
+        let (x_plus_1, y_plus_2) = (x + 1u32, y + 2u32);
+        let b = true;
+        let call_result = foo(x_plus_1);
+        let array_access = arr[3u8];
+        return (t.0, t.1, t.2, x_plus_1, y_plus_2, b, call_result, array_access);
+    }
+
+    inline foo(x: u32) -> u32 {
+        return x * x;
+    }
+}

--- a/tests/tests/compiler/type_inference/futures.leo
+++ b/tests/tests/compiler/type_inference/futures.leo
@@ -1,0 +1,35 @@
+program child.aleo {
+    async transition foo() -> Future {
+        return foo_();
+    }
+
+    async function foo_() {}
+
+    async transition bar() -> Future {
+        return bar_();
+    }
+
+    async function bar_() {}
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+
+program type_inference.aleo {
+    async transition t1() -> (u64, Future) {
+        let f = child.aleo/foo();
+        let r = foo(f);
+        return (42u64, r);
+    }
+
+    async transition t2() -> (u64, Future) {
+        let f = child.aleo/bar();
+        let r = foo(f);
+        return (99u64, r);
+    }
+
+    async function foo(fut: Future) {
+        fut.await();
+    }
+}

--- a/tests/tests/compiler/type_inference/futures_fail.leo
+++ b/tests/tests/compiler/type_inference/futures_fail.leo
@@ -1,0 +1,35 @@
+program child.aleo {
+    async transition foo() -> Future {
+        return foo_();
+    }
+
+    async function foo_() {}
+
+    async transition bar() -> Future {
+        return bar_();
+    }
+
+    async function bar_() {}
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+
+program type_inference.aleo {
+    async transition t1() -> (u64, Future) {
+        let f: u32 = child.aleo/foo();
+        let r: u8 = foo(f);
+        return (42u64, r);
+    }
+
+    async transition t2() -> (u64, Future) {
+        let f: (u8, u8) = child.aleo/bar();
+        let r: bool = foo(f);
+        return (99u64, r);
+    }
+
+    async function foo(fut: Future) {
+        fut.await();
+    }
+}

--- a/tests/tests/parser-statement/statement/definition_fail.leo
+++ b/tests/tests/parser-statement/statement/definition_fail.leo
@@ -1,46 +1,46 @@
 
-let mut x = expr;
+let x = expr;
 
-let mut x = ();
+let x = ();
 
-let mut x = x+y;
+let x = x+y;
 
-let mut x = (x,y);
+let x = (x,y);
 
-let mut x = x();
-
-
-constant mut x = expr;
-
-constant mut x = ();
-
-constant mut x = x+y;
-
-constant mut x = (x,y);
-
-constant mut x = x();
+let x = x();
 
 
-let mut x: u32 = expr;
+const x = expr;
 
-let mut x: u32 = ();
+const x = ();
 
-let mut x: u32 = x+y;
+const x = x+y;
 
-let mut x: u32 = (x,y);
+const x = (x,y);
 
-let mut x: u32 = x();
+const x = x();
 
 
-constant mut x: u32 = expr;
+let x: u32 = expr;
 
-constant mut x: u32 = ();
+let x: u32 = ();
 
-constant mut x: u32 = x+y;
+let x: u32 = x+y;
 
-constant mut x: u32 = (x,y);
+let x: u32 = (x,y);
 
-constant mut x: u32 = x();
+let x: u32 = x();
+
+
+const x: u32 = expr;
+
+const x: u32 = ();
+
+const x: u32 = x+y;
+
+const x: u32 = (x,y);
+
+const x: u32 = x();
 
 
 let (x,y,,) = ();
@@ -52,9 +52,9 @@ let (x,,y) = ();
 let x: [u8; (2,,)] = [[0,0], [0,0]];
 
 
-let x: constant = expr;
+let x: const = expr;
 
-constant x: let = expr;
+const x: let = expr;
 
 let
 


### PR DESCRIPTION
## Motivation

Closes #28630

The goal is to make it easy to define variables so that something like this would work:
```
let x = 1u32;
let y = Foo { .. };
// .. etc
```
where the types of `x` and `y` are automatically set by the compiler.

- `let` type annotation is now optional
- Continue to error out on annotations that don't match the type of the RHS
- Infer the types of defined variables from the type of the RHS.
- Continue to handle tuples and their errors as before. This error is no longer used though:
```rust
@formatted
    invalid_tuple {
        args: (),
        msg: "Tuples must be explicitly typed in Leo".to_string(),
        help: Some("The function definition must match the function return statement".to_string()),
    }
```

## Test Plan
- A few tests now emit the intended errors. How to slightly modify a few of them.
- Added two new tests