### PR TITLE
Disallow some illegal names

### DIFF
--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -1044,4 +1044,18 @@ create_messages!(
         msg: format!("Cannot assign to type `{ty}` or a member thereof."),
         help: Some("External record types and tuples containing them may not be assigned to.".to_string()),
     }
+
+    @formatted
+    illegal_name {
+        args: (item_name: impl Display, item_type: impl Display, keyword: impl Display),
+        msg: format!("`{item_name}` is an invalid {item_type} name. A {item_type} cannot have \"{keyword}\" in its name."),
+        help: None,
+    }
+
+    @formatted
+    record_prefixed_by_other_record {
+        args: (r1: impl Display, r2: impl Display),
+        msg: format!("Record name `{r1}` is prefixed by the record name `{r2}`. Record names must not be prefixes of other record names."),
+        help: None,
+    }
 );

--- a/tests/expectations/compiler/records/nested_record_4_fail.out
+++ b/tests/expectations/compiler/records/nested_record_4_fail.out
@@ -6,22 +6,22 @@ Error [ETYC0372050]: A record cannot contain a tuple.
 Error [ETYC0372050]: A struct cannot contain a tuple.
     --> compiler-test:9:9
      |
-   9 |         bar: (Token, Token),
+   9 |         bar: (Token2, Token2),
      |         ^^^
 Error [ETYC0372030]: A struct or record cannot contain another record.
     --> compiler-test:9:9
      |
-   9 |         bar: (Token, Token),
+   9 |         bar: (Token2, Token2),
      |         ^^^
      |
-     = Remove the record `Token` from `Bar`.
+     = Remove the record `Token2` from `Bar`.
 Error [ETYC0372030]: A struct or record cannot contain another record.
     --> compiler-test:9:9
      |
-   9 |         bar: (Token, Token),
+   9 |         bar: (Token2, Token2),
      |         ^^^
      |
-     = Remove the record `Token` from `Bar`.
+     = Remove the record `Token2` from `Bar`.
 Error [ETYC0372083]: A program must have at least one transition function.
     --> compiler-test:2:9
      |

--- a/tests/expectations/compiler/symbols/illegal_names_fail.out
+++ b/tests/expectations/compiler/symbols/illegal_names_fail.out
@@ -1,0 +1,35 @@
+Error [ETYC0372132]: `fooaleobar` is an invalid program name. A program cannot have "aleo" in its name.
+    --> compiler-test:5:9
+     |
+   5 | program fooaleobar.aleo {
+     |         ^^^^^^^^^^
+Error [ETYC0372133]: Record name `FooBar` is prefixed by the record name `Foo`. Record names must not be prefixes of other record names.
+    --> compiler-test:17:12
+     |
+  17 |     record FooBar {
+     |            ^^^^^^
+Error [ETYC0372133]: Record name `FooBarBaz` is prefixed by the record name `FooBar`. Record names must not be prefixes of other record names.
+    --> compiler-test:12:12
+     |
+  12 |     record FooBarBaz {
+     |            ^^^^^^^^^
+Error [ETYC0372132]: `FooaleoBar` is an invalid record name. A record cannot have "aleo" in its name.
+    --> compiler-test:22:12
+     |
+  22 |     record FooaleoBar {
+     |            ^^^^^^^^^^
+Error [ETYC0372132]: `aaleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+    --> compiler-test:24:9
+     |
+  24 |         aaleob: u32,
+     |         ^^^^^^
+Error [ETYC0372132]: `aleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+    --> compiler-test:25:9
+     |
+  25 |         aleob: u32,
+     |         ^^^^^
+Error [ETYC0372132]: `daleo` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+    --> compiler-test:26:9
+     |
+  26 |         daleo: u32,
+     |         ^^^^^

--- a/tests/expectations/compiler/symbols/illegal_names_in_library_fail.out
+++ b/tests/expectations/compiler/symbols/illegal_names_in_library_fail.out
@@ -1,0 +1,35 @@
+Error [ETYC0372132]: `childaleo` is an invalid program name. A program cannot have "aleo" in its name.
+    --> compiler-test:1:9
+     |
+   1 | program childaleo.aleo {
+     |         ^^^^^^^^^
+Error [ETYC0372133]: Record name `FooBar` is prefixed by the record name `Foo`. Record names must not be prefixes of other record names.
+    --> compiler-test:10:12
+     |
+  10 |     record FooBar {
+     |            ^^^^^^
+Error [ETYC0372133]: Record name `FooBarBaz` is prefixed by the record name `FooBar`. Record names must not be prefixes of other record names.
+    --> compiler-test:6:12
+     |
+   6 |     record FooBarBaz {
+     |            ^^^^^^^^^
+Error [ETYC0372132]: `FooaleoBar` is an invalid record name. A record cannot have "aleo" in its name.
+    --> compiler-test:14:12
+     |
+  14 |     record FooaleoBar {
+     |            ^^^^^^^^^^
+Error [ETYC0372132]: `aaleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+    --> compiler-test:16:9
+     |
+  16 |         aaleob: u32,
+     |         ^^^^^^
+Error [ETYC0372132]: `aleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+    --> compiler-test:17:9
+     |
+  17 |         aleob: u32,
+     |         ^^^^^
+Error [ETYC0372132]: `daleo` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+    --> compiler-test:18:9
+     |
+  18 |         daleo: u32,
+     |         ^^^^^

--- a/tests/tests/compiler/records/nested_record_4_fail.leo
+++ b/tests/tests/compiler/records/nested_record_4_fail.leo
@@ -6,10 +6,10 @@ program test.aleo {
     }
 
     struct Bar {
-        bar: (Token, Token),
+        bar: (Token2, Token2),
     }
 
-    record Token {
+    record Token2 {
         owner: address,
         amount: u64,
     }

--- a/tests/tests/compiler/symbols/illegal_names_fail.leo
+++ b/tests/tests/compiler/symbols/illegal_names_fail.leo
@@ -1,0 +1,39 @@
+program child.aleo {
+    record Foo {
+        owner: address,
+        val: u32,
+    }
+
+    transition bar() {}
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+
+program fooaleobar.aleo {
+    // This shouldn't conflict with child.aleo/Foo
+    record Foo {
+        owner: address,
+    }
+
+    // Foo and FooBar are both prefixes. Shouldn't conflict with child.aleo/Foo though.
+    record FooBarBaz {
+        owner: address,
+    }
+
+    // Foo is a prefix
+    record FooBar {
+        owner: address,
+    }
+
+    // Foo is a prefix and also it has aleo in the name. Also, the fields have aleo in their names.
+    record FooaleoBar {
+        owner: address,
+        aaleob: u32,
+        aleob: u32,
+        daleo: u32,
+    }
+
+    transition foo () {}
+}

--- a/tests/tests/compiler/symbols/illegal_names_in_library_fail.leo
+++ b/tests/tests/compiler/symbols/illegal_names_in_library_fail.leo
@@ -1,0 +1,29 @@
+program childaleo.aleo {
+    record Foo {
+        owner: address,
+    }
+
+    record FooBarBaz {
+        owner: address,
+    }
+
+    record FooBar {
+        owner: address,
+    }
+
+    record FooaleoBar {
+        owner: address,
+        aaleob: u32,
+        aleob: u32,
+        daleo: u32,
+    }
+    transition bar() {}
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+
+program foo.aleo {
+    transition foo () {}
+}


### PR DESCRIPTION
Specifically, enforce the following rules:

1. A program ID must not contain the keyword "aleo" in the program name.
2. A record name must not contain the keyword "aleo".
3. Record names must not be prefixes of other record names.
4. Record entry names must not contain the keyword "aleo".
