### PR TITLE
Type inference for loop iterators

### DIFF
--- a/compiler/ast/src/statement/iteration.rs
+++ b/compiler/ast/src/statement/iteration.rs
@@ -27,7 +27,7 @@ pub struct IterationStatement {
     /// The binding / variable to introduce in the body `block`.
     pub variable: Identifier,
     /// The type of the iteration.
-    pub type_: Type,
+    pub type_: Option<Type>,
     /// The start of the iteration.
     pub start: Expression,
     /// The end of the iteration, possibly `inclusive`.
@@ -46,7 +46,11 @@ pub struct IterationStatement {
 impl fmt::Display for IterationStatement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let eq = if self.inclusive { "=" } else { "" };
-        writeln!(f, "for {}: {} in {}..{eq}{} {{", self.variable, self.type_, self.start, self.stop)?;
+        if let Some(ty) = &self.type_ {
+            writeln!(f, "for {}: {} in {}..{eq}{} {{", self.variable, ty, self.start, self.stop)?;
+        } else {
+            writeln!(f, "for {} in {}..{eq}{} {{", self.variable, self.start, self.stop)?;
+        }
         for stmt in self.block.statements.iter() {
             writeln!(f, "{}{}", Indent(stmt), stmt.semicolon())?;
         }

--- a/compiler/passes/src/loop_unrolling/statement.rs
+++ b/compiler/passes/src/loop_unrolling/statement.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::{Expression::Literal, Type::Integer, *};
+use leo_ast::{Expression::Literal, *};
 use leo_errors::LoopUnrollerError;
 
 use super::UnrollingVisitor;
@@ -55,39 +55,20 @@ impl StatementReconstructor for UnrollingVisitor<'_> {
         let start_value = Value::try_from(start_lit).unwrap();
         let stop_value = Value::try_from(stop_lit).unwrap();
 
-        // Ensure loop bounds are increasing. This cannot be done in the type checker because constant propagation must happen first.
-        if match (input.type_.clone(), &start_value, &stop_value) {
-            (Integer(IntegerType::I8), Value::I8(lower_bound, _), Value::I8(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::I16), Value::I16(lower_bound, _), Value::I16(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::I32), Value::I32(lower_bound, _), Value::I32(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::I64), Value::I64(lower_bound, _), Value::I64(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::I128), Value::I128(lower_bound, _), Value::I128(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::U8), Value::U8(lower_bound, _), Value::U8(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::U16), Value::U16(lower_bound, _), Value::U16(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::U32), Value::U32(lower_bound, _), Value::U32(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::U64), Value::U64(lower_bound, _), Value::U64(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            (Integer(IntegerType::U128), Value::U128(lower_bound, _), Value::U128(upper_bound, _)) => {
-                lower_bound >= upper_bound
-            }
-            _ => panic!("Type checking guarantees that the loop bounds have same type as loop variable."),
+        // Ensure loop bounds are increasing. This cannot be done in the type checker because constant propagation must
+        // happen first.
+        if match (&start_value, &stop_value) {
+            (Value::I8(lower_bound, _), Value::I8(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::I16(lower_bound, _), Value::I16(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::I32(lower_bound, _), Value::I32(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::I64(lower_bound, _), Value::I64(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::I128(lower_bound, _), Value::I128(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::U8(lower_bound, _), Value::U8(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::U16(lower_bound, _), Value::U16(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::U32(lower_bound, _), Value::U32(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::U64(lower_bound, _), Value::U64(upper_bound, _)) => lower_bound >= upper_bound,
+            (Value::U128(lower_bound, _), Value::U128(upper_bound, _)) => lower_bound >= upper_bound,
+            _ => panic!("Type checking guarantees that the loop bounds have same type and that they are integers."),
         } {
             self.emit_err(LoopUnrollerError::loop_range_decreasing(input.stop.span()));
         }

--- a/compiler/passes/src/loop_unrolling/visitor.rs
+++ b/compiler/passes/src/loop_unrolling/visitor.rs
@@ -106,13 +106,17 @@ impl UnrollingVisitor<'_> {
     fn unroll_single_iteration<I: LoopBound>(&mut self, input: &IterationStatement, iteration_count: I) -> Statement {
         // Construct a new node ID.
         let const_id = self.state.node_builder.next_id();
+
+        let iterator_type =
+            self.state.type_table.get(&input.variable.id()).expect("guaranteed to have a type after type checking");
+
         // Update the type table.
-        self.state.type_table.insert(const_id, input.type_.clone());
+        self.state.type_table.insert(const_id, iterator_type.clone());
 
         let outer_block_id = self.state.node_builder.next_id();
 
         // Reconstruct `iteration_count` as a `Literal`.
-        let Type::Integer(integer_type) = &input.type_ else {
+        let Type::Integer(integer_type) = &iterator_type else {
             unreachable!("Type checking enforces that the iteration variable is of integer type");
         };
 

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -1059,4 +1059,10 @@ create_messages!(
         msg: format!("Record name `{r1}` is prefixed by the record name `{r2}`. Record names must not be prefixes of other record names."),
         help: None,
     }
+    @formatted
+    range_bounds_type_mismatch{
+        args: (),
+        msg: format!("mismatched types in loop iterator range bounds"),
+        help: None,
+    }
 );

--- a/tests/expectations/compiler/constants/constant_loop_bound_type_mismatch_fail.out
+++ b/tests/expectations/compiler/constants/constant_loop_bound_type_mismatch_fail.out
@@ -3,3 +3,8 @@ Error [ETYC0372117]: Expected type `u8` but type `u32` was found.
      |
    7 |         for i: u8 in START..STOP {
      |                      ^^^^^
+Error [ETYC0372134]: mismatched types in loop iterator range bounds
+    --> compiler-test:7:22
+     |
+   7 |         for i: u8 in START..STOP {
+     |                      ^^^^^^^^^^^

--- a/tests/expectations/compiler/type_inference/loop_iterators.out
+++ b/tests/expectations/compiler/type_inference/loop_iterators.out
@@ -1,0 +1,17 @@
+program test.aleo;
+
+mapping m:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    async main into r0;
+    output r0 as test.aleo/main.future;
+
+finalize main:
+    set 3u32 into m[1u32];
+    set 4u32 into m[1u32];
+    set 5u32 into m[1u32];
+    set 4u32 into m[2u32];
+    set 5u32 into m[2u32];
+    set 5u32 into m[3u32];

--- a/tests/expectations/compiler/type_inference/loop_iterators_fail.out
+++ b/tests/expectations/compiler/type_inference/loop_iterators_fail.out
@@ -1,0 +1,30 @@
+Error [ETYC0372134]: mismatched types in loop iterator range bounds
+    --> compiler-test:3:18
+     |
+   3 |         for i in 1u8..2u16 {
+     |                  ^^^^^^^^^
+Error [ETYC0372117]: Expected type `u8` but type `u32` was found.
+    --> compiler-test:4:26
+     |
+   4 |             for j: u8 in 0u32..1u32 {
+     |                          ^^^^
+Error [ETYC0372117]: Expected type `u8` but type `u32` was found.
+    --> compiler-test:4:32
+     |
+   4 |             for j: u8 in 0u32..1u32 {
+     |                                ^^^^
+Error [ETYC0372117]: Expected an integer but type `field` was found.
+    --> compiler-test:9:18
+     |
+   9 |         for i in 1field..2scalar {
+     |                  ^^^^^^
+Error [ETYC0372117]: Expected an integer but type `scalar` was found.
+    --> compiler-test:9:26
+     |
+   9 |         for i in 1field..2scalar {
+     |                          ^^^^^^^
+Error [ETYC0372134]: mismatched types in loop iterator range bounds
+    --> compiler-test:9:18
+     |
+   9 |         for i in 1field..2scalar {
+     |                  ^^^^^^^^^^^^^^^

--- a/tests/expectations/parser-statement/statement/iteration.out
+++ b/tests/expectations/parser-statement/statement/iteration.out
@@ -301,3 +301,302 @@
   }
 }
 
+{
+  "Iteration": {
+    "variable": {
+      "name": "x",
+      "span": {
+        "lo": 168,
+        "hi": 169
+      },
+      "id": 0
+    },
+    "type_": null,
+    "start": {
+      "Literal": {
+        "span": {
+          "lo": 173,
+          "hi": 176
+        },
+        "id": 1,
+        "variant": {
+          "Integer": [
+            "U8",
+            "0"
+          ]
+        }
+      }
+    },
+    "stop": {
+      "Literal": {
+        "span": {
+          "lo": 178,
+          "hi": 181
+        },
+        "id": 2,
+        "variant": {
+          "Integer": [
+            "U8",
+            "7"
+          ]
+        }
+      }
+    },
+    "inclusive": false,
+    "block": {
+      "statements": [],
+      "span": {
+        "lo": 182,
+        "hi": 184
+      },
+      "id": 3
+    },
+    "span": {
+      "lo": 164,
+      "hi": 184
+    },
+    "id": 4
+  }
+}
+
+{
+  "Iteration": {
+    "variable": {
+      "name": "x",
+      "span": {
+        "lo": 189,
+        "hi": 190
+      },
+      "id": 0
+    },
+    "type_": null,
+    "start": {
+      "Literal": {
+        "span": {
+          "lo": 194,
+          "hi": 198
+        },
+        "id": 1,
+        "variant": {
+          "Integer": [
+            "I64",
+            "0"
+          ]
+        }
+      }
+    },
+    "stop": {
+      "Literal": {
+        "span": {
+          "lo": 200,
+          "hi": 204
+        },
+        "id": 2,
+        "variant": {
+          "Integer": [
+            "I64",
+            "7"
+          ]
+        }
+      }
+    },
+    "inclusive": false,
+    "block": {
+      "statements": [
+        {
+          "Return": {
+            "expression": {
+              "Literal": {
+                "span": {
+                  "lo": 218,
+                  "hi": 221
+                },
+                "id": 3,
+                "variant": {
+                  "Integer": [
+                    "U8",
+                    "1"
+                  ]
+                }
+              }
+            },
+            "span": {
+              "lo": 211,
+              "hi": 222
+            },
+            "id": 4
+          }
+        }
+      ],
+      "span": {
+        "lo": 205,
+        "hi": 224
+      },
+      "id": 5
+    },
+    "span": {
+      "lo": 185,
+      "hi": 224
+    },
+    "id": 6
+  }
+}
+
+{
+  "Iteration": {
+    "variable": {
+      "name": "x",
+      "span": {
+        "lo": 229,
+        "hi": 230
+      },
+      "id": 0
+    },
+    "type_": null,
+    "start": {
+      "Literal": {
+        "span": {
+          "lo": 234,
+          "hi": 240
+        },
+        "id": 1,
+        "variant": {
+          "Field": "0"
+        }
+      }
+    },
+    "stop": {
+      "Literal": {
+        "span": {
+          "lo": 242,
+          "hi": 246
+        },
+        "id": 2,
+        "variant": {
+          "Integer": [
+            "U8",
+            "99"
+          ]
+        }
+      }
+    },
+    "inclusive": false,
+    "block": {
+      "statements": [
+        {
+          "Return": {
+            "expression": {
+              "Literal": {
+                "span": {
+                  "lo": 260,
+                  "hi": 263
+                },
+                "id": 3,
+                "variant": {
+                  "Integer": [
+                    "U8",
+                    "1"
+                  ]
+                }
+              }
+            },
+            "span": {
+              "lo": 253,
+              "hi": 264
+            },
+            "id": 4
+          }
+        }
+      ],
+      "span": {
+        "lo": 247,
+        "hi": 266
+      },
+      "id": 5
+    },
+    "span": {
+      "lo": 225,
+      "hi": 266
+    },
+    "id": 6
+  }
+}
+
+{
+  "Iteration": {
+    "variable": {
+      "name": "x",
+      "span": {
+        "lo": 271,
+        "hi": 272
+      },
+      "id": 0
+    },
+    "type_": null,
+    "start": {
+      "Literal": {
+        "span": {
+          "lo": 276,
+          "hi": 279
+        },
+        "id": 1,
+        "variant": {
+          "Integer": [
+            "U8",
+            "0"
+          ]
+        }
+      }
+    },
+    "stop": {
+      "Identifier": {
+        "name": "Self",
+        "span": {
+          "lo": 281,
+          "hi": 285
+        },
+        "id": 2
+      }
+    },
+    "inclusive": false,
+    "block": {
+      "statements": [
+        {
+          "Return": {
+            "expression": {
+              "Literal": {
+                "span": {
+                  "lo": 299,
+                  "hi": 302
+                },
+                "id": 3,
+                "variant": {
+                  "Integer": [
+                    "U8",
+                    "1"
+                  ]
+                }
+              }
+            },
+            "span": {
+              "lo": 292,
+              "hi": 303
+            },
+            "id": 4
+          }
+        }
+      ],
+      "span": {
+        "lo": 286,
+        "hi": 305
+      },
+      "id": 5
+    },
+    "span": {
+      "lo": 267,
+      "hi": 305
+    },
+    "id": 6
+  }
+}
+

--- a/tests/expectations/parser-statement/unreachable/define.out
+++ b/tests/expectations/parser-statement/unreachable/define.out
@@ -118,7 +118,7 @@ Error [EPAR0370009]: unexpected string: expected 'expression', found 'as'
      |
    1 | as x = 10u8;
      | ^^
-Error [EPAR0370005]: expected : -- found '='
+Error [EPAR0370005]: expected in -- found '='
     --> test_24:1:7
      |
    1 | for x = 10u8;

--- a/tests/tests/compiler/type_inference/loop_iterators.leo
+++ b/tests/tests/compiler/type_inference/loop_iterators.leo
@@ -1,0 +1,19 @@
+program test.aleo {
+    const START: u32 = 0u32;
+    const STOP: u32 = 6u32;
+
+    mapping m: u32 => u32;
+
+    async function foo() {
+        for i in START+1u32..STOP-2u32 {
+            const SOME: u32 = i + 1u32;
+            for j in SOME+1u32..STOP {
+                m.set(i, j);
+            }
+        }
+    }
+
+    async transition main() -> Future {
+        return foo();
+    }
+}

--- a/tests/tests/compiler/type_inference/loop_iterators_fail.leo
+++ b/tests/tests/compiler/type_inference/loop_iterators_fail.leo
@@ -1,0 +1,17 @@
+program test.aleo {
+    async function bar() {
+        for i in 1u8..2u16 {
+            for j: u8 in 0u32..1u32 {
+
+            }
+        }
+
+        for i in 1field..2scalar {
+
+        }
+    }
+
+    async transition main() -> Future {
+        return bar();
+    }
+}

--- a/tests/tests/parser-statement/statement/iteration.leo
+++ b/tests/tests/parser-statement/statement/iteration.leo
@@ -12,3 +12,17 @@ for x: field in 0field..99u8 {
 for x: bool in 0u8..Self {
     return 1u8;
 }
+
+for x in 0u8..7u8 {}
+
+for x in 0i64..7i64 {
+    return 1u8;
+}
+
+for x in 0field..99u8 {
+    return 1u8;
+}
+
+for x in 0u8..Self {
+    return 1u8;
+}


### PR DESCRIPTION
## Motivation

Closes #28631

This PR allows skipping the type annotation for loop iterators so that one can write
```
for i in 0u32..5u32 { .. }
```

## Test Plan

- new parser and compiler tests
