### PR TITLE
[Refactor] Remove the `Network` parameter from the compiler. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2832,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2853,7 +2853,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2863,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "indexmap",
  "itertools 0.11.0",
@@ -2882,12 +2882,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -2913,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2928,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2960,7 +2960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2972,7 +2972,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2995,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3020,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3031,7 +3031,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3118,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3133,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3144,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3195,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3206,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "rand",
  "rayon",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "anyhow",
  "rand",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3319,7 +3319,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3344,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3355,7 +3355,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3392,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -3446,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3469,7 +3469,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3550,7 +3550,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "indexmap",
  "paste",
@@ -3566,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "bincode",
  "once_cell",
@@ -3579,7 +3579,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3600,7 +3600,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "3.7.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a015246#a015246ccb8a1b16711f372a7bfab59fa89f853b"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=a4573a3#a4573a37575308a94101bee076951bc8686c63e1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.40",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ version = "1.11.1"
 [workspace.dependencies.snarkvm]
 #version = "=3.8.0"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "a015246"
+rev = "a4573a3"
 
 [workspace.dependencies.serde]
 version = "1.0.214"

--- a/compiler/ast/src/common/mod.rs
+++ b/compiler/ast/src/common/mod.rs
@@ -29,6 +29,9 @@ pub use imported_modules::*;
 mod positive_number;
 pub use positive_number::*;
 
+mod network_name;
+pub use network_name::*;
+
 pub mod node;
 
 mod node_builder;

--- a/compiler/ast/src/common/network_name.rs
+++ b/compiler/ast/src/common/network_name.rs
@@ -21,8 +21,9 @@ use snarkvm::prelude::{CanaryV0, MainnetV0, Network, TestnetV0};
 use std::{fmt, str::FromStr};
 
 // Retrievable networks for an external program
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum NetworkName {
+    #[default]
     #[serde(rename = "testnet")]
     TestnetV0,
     #[serde(rename = "mainnet")]

--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -61,11 +61,12 @@ impl<N: Network> Compiler<N> {
         let source_file = with_session_globals(|s| s.source_map.new_source(source, filename));
 
         // Use the parser to construct the abstract syntax tree (ast).
-        self.state.ast = leo_parser::parse_ast::<N>(
+        self.state.ast = leo_parser::parse_ast(
             self.state.handler.clone(),
             &self.state.node_builder,
             &source_file.src,
             source_file.absolute_start,
+            self.state.network,
         )?;
 
         // Check that the name of its program scope matches the expected name.

--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -21,13 +21,11 @@
 use crate::{AstSnapshots, CompilerOptions};
 
 pub use leo_ast::Ast;
-use leo_ast::Stub;
+use leo_ast::{NetworkName, Stub};
 use leo_errors::{CompilerError, Handler, Result};
 use leo_package::UpgradeConfig;
 use leo_passes::*;
 use leo_span::{Symbol, source_map::FileName, with_session_globals};
-
-use snarkvm::prelude::Network;
 
 use indexmap::{IndexMap, IndexSet};
 use std::{
@@ -36,7 +34,7 @@ use std::{
 };
 
 /// The primary entry point of the Leo compiler.
-pub struct Compiler<N: Network> {
+pub struct Compiler {
     /// The path to where the compiler outputs all generated files.
     output_directory: PathBuf,
     /// The program name,
@@ -51,11 +49,9 @@ pub struct Compiler<N: Network> {
     pub statements_before_dce: u32,
     /// How many statements were in the AST after DCE?
     pub statements_after_dce: u32,
-    // Allows the compiler to be generic over the network.
-    phantom: std::marker::PhantomData<N>,
 }
 
-impl<N: Network> Compiler<N> {
+impl Compiler {
     pub fn parse(&mut self, source: &str, filename: FileName) -> Result<()> {
         // Register the source in the source map.
         let source_file = with_session_globals(|s| s.source_map.new_source(source, filename));
@@ -99,6 +95,7 @@ impl<N: Network> Compiler<N> {
     }
 
     /// Returns a new Leo compiler.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         expected_program_name: Option<String>,
         is_test: bool,
@@ -107,16 +104,16 @@ impl<N: Network> Compiler<N> {
         compiler_options: Option<CompilerOptions>,
         import_stubs: IndexMap<Symbol, Stub>,
         upgrade_config: Option<UpgradeConfig>,
+        network: NetworkName,
     ) -> Self {
         Self {
-            state: CompilerState { handler, upgrade_config, is_test, ..Default::default() },
+            state: CompilerState { handler, upgrade_config, is_test, network, ..Default::default() },
             output_directory,
             program_name: expected_program_name,
             compiler_options: compiler_options.unwrap_or_default(),
             import_stubs,
             statements_before_dce: 0,
             statements_after_dce: 0,
-            phantom: Default::default(),
         }
     }
 
@@ -138,17 +135,13 @@ impl<N: Network> Compiler<N> {
 
     /// Runs the compiler stages.
     pub fn intermediate_passes(&mut self) -> Result<()> {
-        let type_checking_config = TypeCheckingInput {
-            max_array_elements: N::MAX_ARRAY_ELEMENTS,
-            max_mappings: N::MAX_MAPPINGS,
-            max_functions: N::MAX_FUNCTIONS,
-        };
+        let type_checking_config = TypeCheckingInput::new(self.state.network);
 
         self.do_pass::<SymbolTableCreation>(())?;
 
-        self.do_pass::<TypeChecking<N>>(type_checking_config.clone())?;
+        self.do_pass::<TypeChecking>(type_checking_config.clone())?;
 
-        self.do_pass::<StaticAnalyzing<N>>(())?;
+        self.do_pass::<StaticAnalyzing>(())?;
 
         self.do_pass::<ConstPropUnrollAndMorphing>(type_checking_config)?;
 
@@ -184,7 +177,7 @@ impl<N: Network> Compiler<N> {
         // Run the intermediate compiler stages.
         self.intermediate_passes()?;
         // Run code generation.
-        let bytecode = CodeGenerating::<N>::do_pass((), &mut self.state)?;
+        let bytecode = CodeGenerating::do_pass((), &mut self.state)?;
         Ok(bytecode)
     }
 

--- a/compiler/compiler/src/test_compiler.rs
+++ b/compiler/compiler/src/test_compiler.rs
@@ -16,7 +16,7 @@
 
 use crate::Compiler;
 
-use leo_ast::Stub;
+use leo_ast::{NetworkName, Stub};
 use leo_disassembler::disassemble_from_str;
 use leo_errors::{BufferEmitter, Handler, LeoError};
 use leo_package::UpgradeConfig;
@@ -40,7 +40,7 @@ pub fn whole_compile(
     import_stubs: IndexMap<Symbol, Stub>,
     upgrade_config: Option<UpgradeConfig>,
 ) -> Result<(String, String), LeoError> {
-    let mut compiler = Compiler::<TestnetV0>::new(
+    let mut compiler = Compiler::new(
         None,
         /* is_test (a Leo test) */ false,
         handler.clone(),
@@ -48,6 +48,7 @@ pub fn whole_compile(
         None,
         import_stubs,
         upgrade_config,
+        NetworkName::TestnetV0,
     );
 
     let filename = FileName::Custom("compiler-test".into());

--- a/compiler/compiler/src/test_execution.rs
+++ b/compiler/compiler/src/test_execution.rs
@@ -16,7 +16,7 @@
 
 use crate::{Compiler, run_with_ledger};
 
-use leo_ast::Stub;
+use leo_ast::{NetworkName, Stub};
 use leo_disassembler::disassemble_from_str;
 use leo_errors::{BufferEmitter, Handler, LeoError, Result};
 use leo_span::{Symbol, create_session_if_not_set_then, source_map::FileName};
@@ -37,7 +37,7 @@ fn whole_compile(
     handler: &Handler,
     import_stubs: IndexMap<Symbol, Stub>,
 ) -> Result<(String, String), LeoError> {
-    let mut compiler = Compiler::<CurrentNetwork>::new(
+    let mut compiler = Compiler::new(
         None,
         /* is_test (a Leo test) */ false,
         handler.clone(),
@@ -45,6 +45,7 @@ fn whole_compile(
         None,
         import_stubs,
         None,
+        NetworkName::TestnetV0,
     );
 
     let filename = FileName::Custom("execution-test".into());

--- a/compiler/parser/examples/parser.rs
+++ b/compiler/parser/examples/parser.rs
@@ -16,7 +16,7 @@
 
 #![forbid(unsafe_code)]
 
-use leo_ast::{Ast, NodeBuilder};
+use leo_ast::{Ast, NetworkName, NodeBuilder};
 use leo_errors::Handler;
 use leo_span::create_session_if_not_set_then;
 
@@ -53,17 +53,19 @@ fn main() -> Result<(), String> {
         Handler::with(|h| {
             let node_builder = NodeBuilder::default();
             let ast = match opt.network.as_str() {
-                "mainnet" => leo_parser::parse_ast::<snarkvm::prelude::MainnetV0>(
+                "mainnet" => leo_parser::parse_ast(
                     h.clone(),
                     &node_builder,
                     &code.src,
                     code.absolute_start,
+                    NetworkName::TestnetV0,
                 ),
-                "testnet" => leo_parser::parse_ast::<snarkvm::prelude::TestnetV0>(
+                "testnet" => leo_parser::parse_ast(
                     h.clone(),
                     &node_builder,
                     &code.src,
                     code.absolute_start,
+                    NetworkName::TestnetV0,
                 ),
                 _ => panic!("Invalid network"),
             }?;

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -30,20 +30,19 @@ pub(crate) use tokenizer::*;
 pub mod parser;
 pub use parser::*;
 
-use leo_ast::{Ast, NodeBuilder};
+use leo_ast::{Ast, NetworkName, NodeBuilder};
 use leo_errors::{Handler, Result};
-
-use snarkvm::prelude::Network;
 
 #[cfg(test)]
 mod test;
 
 /// Creates a new AST from a given file path and source code text.
-pub fn parse_ast<N: Network>(
+pub fn parse_ast(
     handler: Handler,
     node_builder: &NodeBuilder,
     source: &str,
     start_pos: u32,
+    network: NetworkName,
 ) -> Result<Ast> {
-    Ok(Ast::new(parse::<N>(handler, node_builder, source, start_pos)?))
+    Ok(Ast::new(parse(handler, node_builder, source, start_pos, network)?))
 }

--- a/compiler/parser/src/parser/context.rs
+++ b/compiler/parser/src/parser/context.rs
@@ -20,13 +20,13 @@ use leo_ast::*;
 use leo_errors::{Handler, ParserError, Result};
 use leo_span::{Span, Symbol, with_session_globals};
 
-use snarkvm::prelude::{Field, Network};
+use snarkvm::prelude::{CanaryV0, Field, MainnetV0, TestnetV0};
 
-use std::{fmt::Display, marker::PhantomData, mem};
+use std::{fmt::Display, mem};
 
 /// Stores a program in tokenized format plus additional context.
 /// May be converted into a [`Program`] AST by parsing all tokens.
-pub(crate) struct ParserContext<'a, N: Network> {
+pub(crate) struct ParserContext<'a> {
     /// Handler used to side-channel emit errors from the parser.
     pub(crate) handler: Handler,
     /// Counter used to generate unique node ids.
@@ -43,16 +43,21 @@ pub(crate) struct ParserContext<'a, N: Network> {
     pub(crate) disallow_struct_construction: bool,
     /// The name of the program being parsed.
     pub(crate) program_name: Option<Symbol>,
-    // Allows the parser to be generic over the network.
-    phantom: PhantomData<N>,
+    /// The network.
+    pub(crate) network: NetworkName,
 }
 
 /// Dummy span used to appease borrow checker.
 const DUMMY_EOF: SpannedToken = SpannedToken { token: Token::Eof, span: Span::dummy() };
 
-impl<'a, N: Network> ParserContext<'a, N> {
+impl<'a> ParserContext<'a> {
     /// Returns a new [`ParserContext`] type given a vector of tokens.
-    pub fn new(handler: Handler, node_builder: &'a NodeBuilder, mut tokens: Vec<SpannedToken>) -> Self {
+    pub fn new(
+        handler: Handler,
+        node_builder: &'a NodeBuilder,
+        mut tokens: Vec<SpannedToken>,
+        network: NetworkName,
+    ) -> Self {
         // Strip out comments.
         tokens.retain(|x| !matches!(x.token, Token::CommentLine(_) | Token::CommentBlock(_)));
         // For performance we reverse so that we get cheap `.pop()`s.
@@ -67,7 +72,7 @@ impl<'a, N: Network> ParserContext<'a, N> {
             token,
             tokens,
             program_name: None,
-            phantom: Default::default(),
+            network,
         };
         p.bump();
         p
@@ -258,7 +263,11 @@ impl<'a, N: Network> ParserContext<'a, N> {
 
     /// Error on identifiers that are longer than SnarkVM allows.
     pub(crate) fn check_identifier(&mut self, identifier: &Identifier) {
-        let field_capacity_bytes: usize = Field::<N>::SIZE_IN_DATA_BITS / 8;
+        let field_capacity_bytes = match self.network {
+            NetworkName::MainnetV0 => Field::<MainnetV0>::SIZE_IN_DATA_BITS / 8,
+            NetworkName::TestnetV0 => Field::<TestnetV0>::SIZE_IN_DATA_BITS / 8,
+            NetworkName::CanaryV0 => Field::<CanaryV0>::SIZE_IN_DATA_BITS / 8,
+        };
         let len = with_session_globals(|sg| identifier.name.as_str(sg, |s| s.len()));
         if len > field_capacity_bytes {
             self.emit_err(ParserError::identifier_too_long(

--- a/compiler/parser/src/parser/file.rs
+++ b/compiler/parser/src/parser/file.rs
@@ -19,7 +19,7 @@ use super::*;
 use leo_errors::{ParserError, Result, TypeCheckerError};
 use leo_span::{Symbol, sym};
 
-impl<N: Network> ParserContext<'_, N> {
+impl ParserContext<'_> {
     /// Returns a [`Program`] AST if all tokens can be consumed and represent a valid Leo program.
     pub fn parse_program(&mut self) -> Result<Program> {
         let mut imports = IndexMap::new();

--- a/compiler/parser/src/parser/mod.rs
+++ b/compiler/parser/src/parser/mod.rs
@@ -25,8 +25,6 @@ use leo_ast::*;
 use leo_errors::{Handler, ParserError, Result};
 use leo_span::Span;
 
-use snarkvm::prelude::Network;
-
 use indexmap::IndexMap;
 use std::unreachable;
 
@@ -39,24 +37,26 @@ mod statement;
 pub(super) mod type_;
 
 /// Creates a new program from a given file path and source code text.
-pub fn parse<N: Network>(
+pub fn parse(
     handler: Handler,
     node_builder: &NodeBuilder,
     source: &str,
     start_pos: u32,
+    network: NetworkName,
 ) -> Result<Program> {
-    let mut tokens = ParserContext::<N>::new(handler, node_builder, crate::tokenize(source, start_pos)?);
+    let mut tokens = ParserContext::new(handler, node_builder, crate::tokenize(source, start_pos)?, network);
 
     tokens.parse_program()
 }
 
-pub fn parse_expression<N: Network>(
+pub fn parse_expression(
     handler: Handler,
     node_builder: &NodeBuilder,
     source: &str,
     start_pos: u32,
+    network: NetworkName,
 ) -> Result<Expression> {
-    let mut context = ParserContext::<N>::new(handler, node_builder, crate::tokenize(source, start_pos)?);
+    let mut context = ParserContext::new(handler, node_builder, crate::tokenize(source, start_pos)?, network);
 
     let expression = context.parse_expression()?;
     if context.token.token == Token::Eof {
@@ -66,13 +66,14 @@ pub fn parse_expression<N: Network>(
     }
 }
 
-pub fn parse_statement<N: Network>(
+pub fn parse_statement(
     handler: Handler,
     node_builder: &NodeBuilder,
     source: &str,
     start_pos: u32,
+    network: NetworkName,
 ) -> Result<Statement> {
-    let mut context = ParserContext::<N>::new(handler, node_builder, crate::tokenize(source, start_pos)?);
+    let mut context = ParserContext::new(handler, node_builder, crate::tokenize(source, start_pos)?, network);
 
     let statement = context.parse_statement()?;
     if context.token.token == Token::Eof {
@@ -82,13 +83,14 @@ pub fn parse_statement<N: Network>(
     }
 }
 
-pub fn parse_constructor<N: Network>(
+pub fn parse_constructor(
     handler: Handler,
     node_builder: &NodeBuilder,
     source: &str,
     start_pos: u32,
+    network: NetworkName,
 ) -> Result<Constructor> {
-    let mut context = ParserContext::<N>::new(handler, node_builder, crate::tokenize(source, start_pos)?);
+    let mut context = ParserContext::new(handler, node_builder, crate::tokenize(source, start_pos)?, network);
 
     let constructor = context.parse_constructor()?;
     if context.token.token == Token::Eof {

--- a/compiler/parser/src/parser/statement.rs
+++ b/compiler/parser/src/parser/statement.rs
@@ -35,7 +35,7 @@ const ASSIGN_TOKENS: &[Token] = &[
     Token::ShlAssign,
 ];
 
-impl<N: Network> ParserContext<'_, N> {
+impl ParserContext<'_> {
     /// Returns a [`Statement`] AST node if the next tokens represent a statement.
     pub(crate) fn parse_statement(&mut self) -> Result<Statement> {
         match &self.token.token {

--- a/compiler/parser/src/parser/type_.rs
+++ b/compiler/parser/src/parser/type_.rs
@@ -39,7 +39,7 @@ pub(super) const TYPE_TOKENS: &[Token] = &[
     Token::U128,
 ];
 
-impl<N: Network> ParserContext<'_, N> {
+impl ParserContext<'_> {
     /// Returns a [`IntegerType`] AST node if the given token is a supported integer type, or [`None`].
     pub(super) fn token_to_int_type(token: &Token) -> Option<IntegerType> {
         Some(match token {

--- a/compiler/passes/src/code_generation/mod.rs
+++ b/compiler/passes/src/code_generation/mod.rs
@@ -18,8 +18,6 @@ use crate::Pass;
 
 use leo_errors::Result;
 
-use snarkvm::prelude::Network;
-
 mod expression;
 
 mod program;
@@ -31,18 +29,16 @@ mod type_;
 mod visitor;
 use visitor::*;
 
-pub struct CodeGenerating<N: Network> {
-    phantom: std::marker::PhantomData<N>,
-}
+pub struct CodeGenerating;
 
-impl<N: Network> Pass for CodeGenerating<N> {
+impl Pass for CodeGenerating {
     type Input = ();
     type Output = String;
 
     const NAME: &str = "CodeGenerating";
 
     fn do_pass(_input: Self::Input, state: &mut crate::CompilerState) -> Result<Self::Output> {
-        let mut visitor = CodeGeneratingVisitor::<N> {
+        let mut visitor = CodeGeneratingVisitor {
             state,
             next_register: 0,
             current_function: None,
@@ -56,7 +52,6 @@ impl<N: Network> Pass for CodeGenerating<N> {
             next_label: 0,
             conditional_depth: 0,
             internal_record_inputs: Default::default(),
-            _phantom: Default::default(),
         };
         let code = visitor.visit_program(visitor.state.ast.as_repr());
         Ok(code)

--- a/compiler/passes/src/code_generation/statement.rs
+++ b/compiler/passes/src/code_generation/statement.rs
@@ -37,7 +37,7 @@ use indexmap::IndexSet;
 use itertools::Itertools as _;
 use std::fmt::Write as _;
 
-impl<N: Network> CodeGeneratingVisitor<'_, N> {
+impl CodeGeneratingVisitor<'_> {
     fn visit_statement(&mut self, input: &Statement) -> String {
         match input {
             Statement::Assert(stmt) => self.visit_assert(stmt),

--- a/compiler/passes/src/code_generation/type_.rs
+++ b/compiler/passes/src/code_generation/type_.rs
@@ -18,7 +18,7 @@ use super::*;
 
 use leo_ast::{Location, Mode, Type};
 
-impl<N: Network> CodeGeneratingVisitor<'_, N> {
+impl CodeGeneratingVisitor<'_> {
     pub fn visit_type(input: &Type) -> String {
         match input {
             Type::Address

--- a/compiler/passes/src/code_generation/visitor.rs
+++ b/compiler/passes/src/code_generation/visitor.rs
@@ -33,7 +33,7 @@ use snarkvm::prelude::{Network, ensure};
 use indexmap::{IndexMap, IndexSet};
 use std::str::FromStr;
 
-pub struct CodeGeneratingVisitor<'a, N: Network> {
+pub struct CodeGeneratingVisitor<'a> {
     pub state: &'a CompilerState,
     /// A counter to track the next available register.
     pub next_register: u64,
@@ -62,7 +62,6 @@ pub struct CodeGeneratingVisitor<'a, N: Network> {
     /// Internal record input registers of the current function.
     /// This is necessary as if we output them, we need to clone them.
     pub internal_record_inputs: IndexSet<String>,
-    pub _phantom: std::marker::PhantomData<N>,
 }
 
 /// This function checks whether or not the constructor is well-formed.
@@ -92,7 +91,7 @@ pub(crate) fn check_snarkvm_constructor<N: Network>(
     Ok(())
 }
 
-impl<N: Network> CodeGeneratingVisitor<'_, N> {
+impl CodeGeneratingVisitor<'_> {
     pub fn next_register(&mut self) -> String {
         self.next_register += 1;
         format!("r{}", self.next_register - 1)

--- a/compiler/passes/src/common/normalizer/mod.rs
+++ b/compiler/passes/src/common/normalizer/mod.rs
@@ -22,6 +22,7 @@ use leo_ast::{
     DefinitionStatement,
     Expression,
     ExpressionReconstructor,
+    Literal,
     LocatorExpression,
     MemberAccess,
     Node,
@@ -84,6 +85,11 @@ impl ExpressionReconstructor for Normalizer {
             .into(),
             Default::default(),
         )
+    }
+
+    fn reconstruct_literal(&mut self, input: Literal) -> (Expression, Self::AdditionalOutput) {
+        let input = normalize_node(input);
+        (Expression::Literal(input), Default::default())
     }
 
     fn reconstruct_locator(&mut self, input: LocatorExpression) -> (Expression, Self::AdditionalOutput) {
@@ -156,6 +162,7 @@ impl StatementReconstructor for Normalizer {
                         DefinitionPlace::Multiple(identifiers.into_iter().map(normalize_node).collect())
                     }
                 },
+                type_: input.type_.map(|t| self.reconstruct_type(t).0),
                 ..input
             }
             .into(),

--- a/compiler/passes/src/const_prop_unroll_and_morphing.rs
+++ b/compiler/passes/src/const_prop_unroll_and_morphing.rs
@@ -25,7 +25,6 @@ use crate::{
     TypeCheckingInput,
     Unrolling,
 };
-use snarkvm::prelude::TestnetV0;
 
 use leo_errors::{CompilerError, Result};
 
@@ -56,7 +55,7 @@ impl Pass for ConstPropUnrollAndMorphing {
 
             // Now run the type checker again to validate and infer types. Again, this is important because the program
             // may have changed significantly after the passes above.
-            TypeChecking::<TestnetV0>::do_pass(input.clone(), state)?;
+            TypeChecking::do_pass(input.clone(), state)?;
 
             if !const_prop_output.changed
                 && !loop_unroll_output.loop_unrolled

--- a/compiler/passes/src/pass.rs
+++ b/compiler/passes/src/pass.rs
@@ -16,7 +16,7 @@
 
 use crate::{Assigner, SymbolTable, TypeTable};
 
-use leo_ast::{Ast, CallGraph, NodeBuilder, StructGraph};
+use leo_ast::{Ast, CallGraph, NetworkName, NodeBuilder, StructGraph};
 use leo_errors::{Handler, LeoWarning, Result};
 use leo_package::UpgradeConfig;
 
@@ -47,6 +47,8 @@ pub struct CompilerState {
     pub warnings: HashSet<LeoWarning>,
     /// Is this a test program?
     pub is_test: bool,
+    /// The network.
+    pub network: NetworkName,
 }
 
 /// A compiler pass.

--- a/compiler/passes/src/static_analysis/constructor_checker.rs
+++ b/compiler/passes/src/static_analysis/constructor_checker.rs
@@ -61,7 +61,7 @@ impl StaticAnalyzingVisitor<'_> {
         }
     }
 
-    // Checks that an `Admin` constructor is well formed.
+    // Checks that an `Admin` constructor is well-formed.
     fn check_admin_constructor(&self, constructor: &Constructor, address: &str) {
         // Verify that the address is valid.
         if match self.state.network {

--- a/compiler/passes/src/static_analysis/constructor_checker.rs
+++ b/compiler/passes/src/static_analysis/constructor_checker.rs
@@ -137,17 +137,16 @@ impl StaticAnalyzingVisitor<'_> {
             .lookup_global(location)
             .map(|variable| match variable.type_ {
                 Type::Mapping(ref mapping_type) => {
-                    mapping_type.key.as_ref() == &key_type
-                        && mapping_type.value.as_ref()
-                            == &Type::Array(ArrayType::new(
-                                Type::Integer(IntegerType::U8),
-                                Expression::Literal(leo_ast::Literal::integer(
-                                    IntegerType::U8,
-                                    "32".to_string(),
-                                    Default::default(),
-                                    Default::default(),
-                                )),
-                            ))
+                    mapping_type.key.as_ref().eq_flat_relaxed(&key_type)
+                        && mapping_type.value.as_ref().eq_flat_relaxed(&Type::Array(ArrayType::new(
+                            Type::Integer(IntegerType::U8),
+                            Expression::Literal(leo_ast::Literal::integer(
+                                IntegerType::U8,
+                                "32".to_string(),
+                                Default::default(),
+                                Default::default(),
+                            )),
+                        )))
                 }
                 _ => false,
             })

--- a/compiler/passes/src/static_analysis/constructor_checker.rs
+++ b/compiler/passes/src/static_analysis/constructor_checker.rs
@@ -71,7 +71,7 @@ impl<N: Network> StaticAnalyzingVisitor<'_, N> {
             ));
         }
         // Construct the expected constructor.
-        let expected = parse_constructor::<N>(&leo_admin_constructor(address));
+        let expected = self.parse_constructor(&leo_admin_constructor(address));
         // Check that the expected constructor matches the given constructor.
         if !constructors_match(constructor, &expected) {
             self.state.handler.emit_err(StaticAnalyzerError::custom_error(
@@ -149,7 +149,7 @@ impl<N: Network> StaticAnalyzingVisitor<'_, N> {
             ));
         }
         // Construct the expected constructor.
-        let expected = parse_constructor::<N>(&leo_checksum_constructor(mapping, key));
+        let expected = self.parse_constructor(&leo_checksum_constructor(mapping, key));
         // Check that the expected constructor matches the given constructor.
         if !constructors_match(constructor, &expected) {
             self.state.handler.emit_err(StaticAnalyzerError::custom_error(
@@ -169,7 +169,7 @@ impl<N: Network> StaticAnalyzingVisitor<'_, N> {
     // Checks that a `NoUpgrade` constructor is well formed.
     fn check_noupgrade_constructor(&self, constructor: &Constructor) {
         // Construct the expected constructor.
-        let expected = parse_constructor::<N>(&leo_noupgrade_constructor());
+        let expected = self.parse_constructor(&leo_noupgrade_constructor());
         // Check that the expected constructor matches the given constructor.
         if !constructors_match(constructor, &expected) {
             self.state.handler.emit_err(StaticAnalyzerError::custom_error(
@@ -179,17 +179,17 @@ impl<N: Network> StaticAnalyzingVisitor<'_, N> {
             ));
         }
     }
-}
 
-// A helper function to parse a constructor string into a Leo constructor.
-fn parse_constructor<N: Network>(constructor_string: &str) -> Constructor {
-    // Initialize a new handler.
-    let handler = Handler::new(BufferEmitter::new());
-    // Initialize a node builder.
-    let node_builder = NodeBuilder::new(0);
-    // Parse the constructor string.
-    leo_parser::parse_constructor::<N>(handler, &node_builder, constructor_string, 0)
-        .expect("The default constructor should be well-formed")
+    // A helper function to parse a constructor string into a Leo constructor.
+    fn parse_constructor(&self, constructor_string: &str) -> Constructor {
+        // Initialize a new handler.
+        let handler = Handler::new(BufferEmitter::new());
+        // Initialize a node builder.
+        let node_builder = NodeBuilder::new(0);
+        // Parse the constructor string.
+        leo_parser::parse_constructor(handler, &node_builder, constructor_string, 0, self.state.network)
+            .expect("The default constructor should be well-formed")
+    }
 }
 
 // A helper function to provide an error message if the constructor is not well formed.

--- a/compiler/passes/src/static_analysis/expression.rs
+++ b/compiler/passes/src/static_analysis/expression.rs
@@ -18,9 +18,7 @@ use super::StaticAnalyzingVisitor;
 
 use leo_ast::*;
 
-use snarkvm::prelude::Network;
-
-impl<N: Network> ExpressionVisitor for StaticAnalyzingVisitor<'_, N> {
+impl ExpressionVisitor for StaticAnalyzingVisitor<'_> {
     type AdditionalInput = ();
     type Output = ();
 

--- a/compiler/passes/src/static_analysis/mod.rs
+++ b/compiler/passes/src/static_analysis/mod.rs
@@ -28,7 +28,6 @@ mod statement;
 mod program;
 
 mod visitor;
-use snarkvm::prelude::Network;
 use visitor::*;
 
 use crate::Pass;
@@ -37,11 +36,9 @@ use leo_ast::ProgramVisitor;
 use leo_errors::Result;
 use leo_span::Symbol;
 
-pub struct StaticAnalyzing<N: Network> {
-    _phantom: std::marker::PhantomData<N>,
-}
+pub struct StaticAnalyzing;
 
-impl<N: Network> Pass for StaticAnalyzing<N> {
+impl Pass for StaticAnalyzing {
     type Input = ();
     type Output = ();
 
@@ -49,13 +46,12 @@ impl<N: Network> Pass for StaticAnalyzing<N> {
 
     fn do_pass(_input: Self::Input, state: &mut crate::CompilerState) -> Result<Self::Output> {
         let ast = std::mem::take(&mut state.ast);
-        let mut visitor = StaticAnalyzingVisitor::<N> {
+        let mut visitor = StaticAnalyzingVisitor {
             state,
             await_checker: AwaitChecker::new(),
             current_program: Symbol::intern(""),
             variant: None,
             non_async_external_call_seen: false,
-            _phantom: Default::default(),
         };
         visitor.visit_program(ast.as_repr());
         visitor.state.handler.last_err().map_err(|e| *e)?;

--- a/compiler/passes/src/static_analysis/program.rs
+++ b/compiler/passes/src/static_analysis/program.rs
@@ -19,9 +19,7 @@ use super::StaticAnalyzingVisitor;
 use leo_ast::{Type, *};
 use leo_errors::{StaticAnalyzerError, StaticAnalyzerWarning};
 
-use snarkvm::prelude::Network;
-
-impl<N: Network> ProgramVisitor for StaticAnalyzingVisitor<'_, N> {
+impl ProgramVisitor for StaticAnalyzingVisitor<'_> {
     fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Set the current program name.
         self.current_program = input.program_id.name.name;

--- a/compiler/passes/src/static_analysis/statement.rs
+++ b/compiler/passes/src/static_analysis/statement.rs
@@ -19,9 +19,7 @@ use crate::ConditionalTreeNode;
 
 use leo_ast::*;
 
-use snarkvm::prelude::Network;
-
-impl<N: Network> StatementVisitor for StaticAnalyzingVisitor<'_, N> {
+impl StatementVisitor for StaticAnalyzingVisitor<'_> {
     fn visit_conditional(&mut self, input: &ConditionalStatement) {
         self.visit_expression(&input.condition, &Default::default());
 

--- a/compiler/passes/src/static_analysis/visitor.rs
+++ b/compiler/passes/src/static_analysis/visitor.rs
@@ -20,9 +20,7 @@ use leo_ast::*;
 use leo_errors::{StaticAnalyzerError, StaticAnalyzerWarning};
 use leo_span::{Span, Symbol};
 
-use snarkvm::prelude::Network;
-
-pub struct StaticAnalyzingVisitor<'a, N: Network> {
+pub struct StaticAnalyzingVisitor<'a> {
     pub state: &'a mut CompilerState,
     /// Struct to store the state relevant to checking all futures are awaited.
     pub await_checker: AwaitChecker,
@@ -32,10 +30,9 @@ pub struct StaticAnalyzingVisitor<'a, N: Network> {
     pub variant: Option<Variant>,
     /// Whether or not a non-async external call has been seen in this function.
     pub non_async_external_call_seen: bool,
-    pub _phantom: std::marker::PhantomData<N>,
 }
 
-impl<N: Network> StaticAnalyzingVisitor<'_, N> {
+impl StaticAnalyzingVisitor<'_> {
     pub fn emit_err(&self, err: StaticAnalyzerError) {
         self.state.handler.emit_err(err);
     }
@@ -108,4 +105,4 @@ impl<N: Network> StaticAnalyzingVisitor<'_, N> {
     }
 }
 
-impl<N: Network> TypeVisitor for StaticAnalyzingVisitor<'_, N> {}
+impl TypeVisitor for StaticAnalyzingVisitor<'_> {}

--- a/compiler/passes/src/type_checking/expression.rs
+++ b/compiler/passes/src/type_checking/expression.rs
@@ -23,7 +23,7 @@ use leo_span::{Span, Symbol, sym};
 
 use itertools::Itertools as _;
 
-impl<N: Network> TypeCheckingVisitor<'_, N> {
+impl TypeCheckingVisitor<'_> {
     pub fn visit_expression_assign(&mut self, input: &Expression) -> Type {
         let ty = match input {
             Expression::ArrayAccess(array_access) => self.visit_array_access_general(array_access, true, &None),
@@ -341,7 +341,7 @@ impl<N: Network> TypeCheckingVisitor<'_, N> {
     }
 }
 
-impl<N: Network> ExpressionVisitor for TypeCheckingVisitor<'_, N> {
+impl ExpressionVisitor for TypeCheckingVisitor<'_> {
     type AdditionalInput = Option<Type>;
     type Output = Type;
 

--- a/compiler/passes/src/type_checking/program.rs
+++ b/compiler/passes/src/type_checking/program.rs
@@ -23,7 +23,7 @@ use leo_span::{Symbol, sym};
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashSet};
 
-impl<N: Network> ProgramVisitor for TypeCheckingVisitor<'_, N> {
+impl ProgramVisitor for TypeCheckingVisitor<'_> {
     fn visit_program(&mut self, input: &Program) {
         // Typecheck the program's stubs.
         input.stubs.iter().for_each(|(symbol, stub)| {

--- a/compiler/passes/src/type_checking/statement.rs
+++ b/compiler/passes/src/type_checking/statement.rs
@@ -23,7 +23,7 @@ use leo_ast::{
 };
 use leo_errors::TypeCheckerError;
 
-impl<N: Network> StatementVisitor for TypeCheckingVisitor<'_, N> {
+impl StatementVisitor for TypeCheckingVisitor<'_> {
     fn visit_statement(&mut self, input: &Statement) {
         // No statements can follow a return statement.
         if self.scope_state.has_return {

--- a/compiler/passes/src/type_checking/type_.rs
+++ b/compiler/passes/src/type_checking/type_.rs
@@ -16,9 +16,8 @@
 
 use super::TypeCheckingVisitor;
 use leo_ast::{ArrayType, Expression, ExpressionVisitor, IntegerType, Node, Type, TypeVisitor};
-use snarkvm::prelude::Network;
 
-impl<N: Network> TypeVisitor for TypeCheckingVisitor<'_, N> {
+impl TypeVisitor for TypeCheckingVisitor<'_> {
     fn visit_array_type(&mut self, input: &ArrayType) {
         self.visit_type(&input.element_type);
         let mut length_type = self.visit_expression(&input.length, &None);

--- a/interpreter/src/cursor_aleo.rs
+++ b/interpreter/src/cursor_aleo.rs
@@ -33,7 +33,6 @@ use snarkvm::{
         Identifier,
         Literal,
         LiteralType,
-        Network as _,
         PlaintextType,
         Register,
         TestnetV0,

--- a/interpreter/src/interpreter.rs
+++ b/interpreter/src/interpreter.rs
@@ -15,7 +15,10 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use leo_ast::interpreter_value::{GlobalId, Value};
+use leo_ast::{
+    NetworkName,
+    interpreter_value::{GlobalId, Value},
+};
 use leo_errors::{CompilerError, Handler, InterpreterHalt, LeoError, Result};
 use leo_passes::{CompilerState, Pass, SymbolTableCreation, TypeChecking, TypeCheckingInput};
 use snarkvm::prelude::Network;
@@ -33,6 +36,8 @@ pub struct Interpreter {
     saved_cursors: Vec<Cursor>,
     filename_to_program: HashMap<PathBuf, String>,
     parsed_inputs: u32,
+    /// The network.
+    network: NetworkName,
 }
 
 #[derive(Clone, Debug)]
@@ -68,6 +73,7 @@ impl Interpreter {
         signer: SvmAddress,
         block_height: u32,
         test_flow: bool, // impacts the type checker
+        network: NetworkName,
     ) -> Result<Self> {
         Self::new_impl(
             &mut leo_source_files.into_iter().map(|p| p.as_ref()),
@@ -75,6 +81,7 @@ impl Interpreter {
             signer,
             block_height,
             test_flow,
+            network,
         )
     }
 
@@ -84,11 +91,12 @@ impl Interpreter {
         let source_file = with_session_globals(|s| s.source_map.new_source(&text, filename));
 
         // Parse
-        state.ast = leo_parser::parse_ast::<TestnetV0>(
+        state.ast = leo_parser::parse_ast(
             state.handler.clone(),
             &state.node_builder,
             &text,
             source_file.absolute_start,
+            state.network,
         )?;
 
         // Only run these two passes from the compiler to make sure that type inference runs and the `type_table` is
@@ -112,6 +120,7 @@ impl Interpreter {
         signer: SvmAddress,
         block_height: u32,
         test_flow: bool,
+        network: NetworkName,
     ) -> Result<Self> {
         let mut cursor: Cursor = Cursor::new(
             true, // really_async
@@ -120,7 +129,7 @@ impl Interpreter {
         );
         let mut filename_to_program = HashMap::new();
 
-        let mut state = CompilerState { is_test: test_flow, ..Default::default() };
+        let mut state = CompilerState { is_test: test_flow, network, ..Default::default() };
 
         for path in leo_source_files {
             let ast = Self::get_ast(path, &mut state)?;
@@ -206,6 +215,7 @@ impl Interpreter {
             saved_cursors: Vec::new(),
             filename_to_program,
             parsed_inputs: 0,
+            network,
         })
     }
 
@@ -275,11 +285,12 @@ impl Interpreter {
                 let source_file = with_session_globals(|globals| globals.source_map.new_source(s, filename));
                 let s = s.trim();
                 if s.ends_with(';') {
-                    let statement = leo_parser::parse_statement::<TestnetV0>(
+                    let statement = leo_parser::parse_statement(
                         self.handler.clone(),
                         &self.node_builder,
                         s,
                         source_file.absolute_start,
+                        self.network,
                     )
                     .map_err(|_e| {
                         LeoError::InterpreterHalt(InterpreterHalt::new("failed to parse statement".into()))
@@ -291,11 +302,12 @@ impl Interpreter {
                         user_initiated: true,
                     });
                 } else {
-                    let expression = leo_parser::parse_expression::<TestnetV0>(
+                    let expression = leo_parser::parse_expression(
                         self.handler.clone(),
                         &self.node_builder,
                         s,
                         source_file.absolute_start,
+                        self.network,
                     )
                     .map_err(|e| {
                         LeoError::InterpreterHalt(InterpreterHalt::new(format!("Failed to parse expression: {e}")))

--- a/interpreter/src/interpreter.rs
+++ b/interpreter/src/interpreter.rs
@@ -102,7 +102,7 @@ impl Interpreter {
         // Only run these two passes from the compiler to make sure that type inference runs and the `type_table` is
         // filled out. Other compiler passes are not necessary at this stage.
         SymbolTableCreation::do_pass((), state)?;
-        TypeChecking::<TestnetV0>::do_pass(
+        TypeChecking::do_pass(
             TypeCheckingInput {
                 max_array_elements: TestnetV0::MAX_ARRAY_ELEMENTS,
                 max_mappings: TestnetV0::MAX_MAPPINGS,

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -19,6 +19,7 @@ use leo_ast::{
     CallExpression,
     ExpressionStatement,
     Identifier,
+    NetworkName,
     Node as _,
     NodeBuilder,
     Statement,
@@ -27,7 +28,7 @@ use leo_ast::{
 use leo_errors::{InterpreterHalt, LeoError, Result};
 use leo_span::{Span, Symbol, source_map::FileName, sym, with_session_globals};
 
-use snarkvm::prelude::{Program, TestnetV0};
+use snarkvm::prelude::{Network, Program, TestnetV0};
 
 use indexmap::IndexMap;
 use std::{
@@ -143,9 +144,10 @@ pub fn find_and_run_tests(
     signer: SvmAddress,
     block_height: u32,
     match_str: &str,
+    network: NetworkName,
 ) -> Result<(Vec<TestFunction>, IndexMap<GlobalId, Result<()>>)> {
     let mut interpreter =
-        Interpreter::new(leo_filenames, aleo_filenames, signer, block_height, true /*test flow*/)?;
+        Interpreter::new(leo_filenames, aleo_filenames, signer, block_height, true /*test flow*/, network)?;
 
     let mut native_test_functions = Vec::new();
 
@@ -244,9 +246,10 @@ pub fn interpret(
     signer: SvmAddress,
     block_height: u32,
     tui: bool,
+    network: NetworkName,
 ) -> Result<()> {
     let mut interpreter =
-        Interpreter::new(leo_filenames, aleo_filenames, signer, block_height, false /* test flow */)?;
+        Interpreter::new(leo_filenames, aleo_filenames, signer, block_height, false /* test flow */, network)?;
 
     let mut user_interface: Box<dyn Ui> =
         if tui { Box::new(ratatui_ui::RatatuiUi::new()) } else { Box::new(dialoguer_input::DialoguerUi::new()) };

--- a/interpreter/src/test.rs
+++ b/interpreter/src/test.rs
@@ -16,6 +16,7 @@
 
 use crate::{Interpreter, InterpreterAction};
 
+use leo_ast::NetworkName;
 use leo_span::create_session_if_not_set_then;
 
 use snarkvm::prelude::{Address, PrivateKey, TestnetV0};
@@ -36,8 +37,8 @@ fn runner_leo_test(test: &str) -> String {
             PrivateKey::from_str(TEST_PRIVATE_KEY).expect("should be able to parse private key");
         let address = Address::try_from(&private_key).expect("should be able to create address");
         let empty: [&PathBuf; 0] = [];
-        let mut interpreter =
-            Interpreter::new([filename].iter(), empty, address, 0, false).expect("creating interpreter");
+        let mut interpreter = Interpreter::new([filename].iter(), empty, address, 0, false, NetworkName::TestnetV0)
+            .expect("creating interpreter");
         match interpreter.action(InterpreterAction::LeoInterpretOver("test.aleo/main()".into())) {
             Err(e) => format!("{e}\n"),
             Ok(None) => "no value received\n".to_string(),

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -15,8 +15,9 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
+use leo_ast::NetworkName;
 use leo_errors::UtilError;
-use leo_package::{Env, NetworkName};
+use leo_package::Env;
 
 #[cfg(not(feature = "only_testnet"))]
 use snarkvm::prelude::{CanaryV0, MainnetV0};

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -16,10 +16,10 @@
 
 use super::*;
 
-use leo_ast::Stub;
+use leo_ast::{NetworkName, Stub};
 use leo_compiler::{AstSnapshots, Compiler, CompilerOptions};
 use leo_errors::{CliError, UtilError};
-use leo_package::{Manifest, NetworkName, Package, UpgradeConfig};
+use leo_package::{Manifest, Package, UpgradeConfig};
 use leo_span::Symbol;
 
 use snarkvm::prelude::{Itertools, MainnetV0, Network, Program, TestnetV0};

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -22,10 +22,9 @@ use leo_errors::{CliError, UtilError};
 use leo_package::{Manifest, Package, UpgradeConfig};
 use leo_span::Symbol;
 
-use snarkvm::prelude::{Itertools, MainnetV0, Network, Program, TestnetV0};
+use snarkvm::prelude::{CanaryV0, Itertools, MainnetV0, Program, TestnetV0};
 
 use indexmap::IndexMap;
-use snarkvm::prelude::CanaryV0;
 use std::path::Path;
 
 impl From<BuildOptions> for CompilerOptions {
@@ -66,16 +65,13 @@ impl Command for LeoBuild {
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Parse the network.
         let network: NetworkName = context.get_network(&self.env_override.network)?.parse()?;
-        match network {
-            NetworkName::MainnetV0 => handle_build::<MainnetV0>(&self, context),
-            NetworkName::TestnetV0 => handle_build::<TestnetV0>(&self, context),
-            NetworkName::CanaryV0 => handle_build::<CanaryV0>(&self, context),
-        }
+        // Build the program.
+        handle_build(&self, context, network)
     }
 }
 
 // A helper function to handle the build command.
-fn handle_build<N: Network>(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Command>::Output> {
+fn handle_build(command: &LeoBuild, context: Context, network: NetworkName) -> Result<<LeoBuild as Command>::Output> {
     let package_path = context.dir()?;
     let home_path = context.home()?;
 
@@ -117,7 +113,7 @@ fn handle_build<N: Network>(command: &LeoBuild, context: Context) -> Result<<Leo
                 };
                 // Load the manifest in local dependency.
                 let manifest = Manifest::read_from_file(directory.join(leo_package::MANIFEST_FILENAME))?;
-                let bytecode = compile_leo_file::<N>(
+                let bytecode = compile_leo_file(
                     source,
                     program.name,
                     program.is_test,
@@ -126,6 +122,7 @@ fn handle_build<N: Network>(command: &LeoBuild, context: Context) -> Result<<Leo
                     command.options.clone(),
                     stubs.clone(),
                     manifest.upgrade,
+                    network,
                 )?;
                 (bytecode, build_path)
             }
@@ -135,7 +132,11 @@ fn handle_build<N: Network>(command: &LeoBuild, context: Context) -> Result<<Leo
         std::fs::write(build_path, &bytecode).map_err(CliError::failed_to_load_instructions)?;
 
         // Track the Stub.
-        let stub = leo_disassembler::disassemble_from_str::<N>(program.name, &bytecode)?;
+        let stub = match network {
+            NetworkName::MainnetV0 => leo_disassembler::disassemble_from_str::<MainnetV0>(program.name, &bytecode),
+            NetworkName::TestnetV0 => leo_disassembler::disassemble_from_str::<TestnetV0>(program.name, &bytecode),
+            NetworkName::CanaryV0 => leo_disassembler::disassemble_from_str::<CanaryV0>(program.name, &bytecode),
+        }?;
         stubs.insert(program.name, stub);
     }
 
@@ -158,7 +159,7 @@ fn handle_build<N: Network>(command: &LeoBuild, context: Context) -> Result<<Leo
 
 /// Compiles a Leo file. Writes and returns the compiled bytecode.
 #[allow(clippy::too_many_arguments)]
-fn compile_leo_file<N: Network>(
+fn compile_leo_file(
     source_file_path: &Path,
     program_name: Symbol,
     is_test: bool,
@@ -167,9 +168,10 @@ fn compile_leo_file<N: Network>(
     options: BuildOptions,
     stubs: IndexMap<Symbol, Stub>,
     upgrade_config: Option<UpgradeConfig>,
+    network: NetworkName,
 ) -> Result<String> {
     // Create a new instance of the Leo compiler.
-    let mut compiler = Compiler::<N>::new(
+    let mut compiler = Compiler::new(
         Some(program_name.to_string()),
         is_test,
         handler.clone(),
@@ -177,19 +179,22 @@ fn compile_leo_file<N: Network>(
         Some(options.into()),
         stubs,
         upgrade_config,
+        network,
     );
 
     // Compile the Leo program into Aleo instructions.
     let bytecode = compiler.compile_from_file(source_file_path)?;
 
     // Get the AVM bytecode.
-    let program = Program::<N>::from_str(&bytecode)?;
-    let checksum = program.to_checksum();
-    let checksum_string = checksum.iter().join(", ");
+    let checksum: String = match network {
+        NetworkName::MainnetV0 => Program::<MainnetV0>::from_str(&bytecode)?.to_checksum().iter().join(", "),
+        NetworkName::TestnetV0 => Program::<TestnetV0>::from_str(&bytecode)?.to_checksum().iter().join(", "),
+        NetworkName::CanaryV0 => Program::<CanaryV0>::from_str(&bytecode)?.to_checksum().iter().join(", "),
+    };
 
     tracing::info!("    \n{} statements before dead code elimination.", compiler.statements_before_dce);
     tracing::info!("    {} statements after dead code elimination.", compiler.statements_after_dce);
-    tracing::info!("    The program checksum is: '[{checksum_string}]'.");
+    tracing::info!("    The program checksum is: '[{checksum}]'.");
 
     tracing::info!("✅ Compiled '{program_name}.aleo' into Aleo instructions.");
     Ok(bytecode)

--- a/leo/cli/commands/common/interactive.rs
+++ b/leo/cli/commands/common/interactive.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use leo_package::NetworkName;
+use leo_ast::NetworkName;
 
 /// Asks the user to confirm an action, with an optional `--yes` override.
 pub fn confirm(prompt: &str, skip_confirmation: bool) -> Result<bool> {

--- a/leo/cli/commands/common/options.rs
+++ b/leo/cli/commands/common/options.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use leo_package::NetworkName;
+use leo_ast::NetworkName;
 use snarkvm::prelude::ConsensusVersion;
 
 /// Compiler Options wrapper for Build command. Also used by other commands which

--- a/leo/cli/commands/common/query.rs
+++ b/leo/cli/commands/common/query.rs
@@ -91,7 +91,14 @@ pub fn handle_broadcast<N: Network>(endpoint: &str, transaction: &Transaction<N>
         .send_json(transaction)
         .map_err(|err| CliError::broadcast_error(err.to_string()))?;
     match response.status() {
-        200 => Ok(response),
+        200 => {
+            println!(
+                "✉️ Broadcasted transaction with:\n  - transaction ID: '{}'\n  - fee ID: '{}'",
+                transaction.id().to_string().bold().yellow(),
+                transaction.fee_transition().expect("Expected a fee in transactions").id().to_string().bold().yellow()
+            );
+            Ok(response)
+        }
         301 => {
             let msg = format!(
                 "⚠️ The endpoint `{endpoint}` has been permanently moved. Try using `https://api.explorer.provable.com/v1` in your `.env` file or via the `--endpoint` flag."

--- a/leo/cli/commands/common/query.rs
+++ b/leo/cli/commands/common/query.rs
@@ -20,7 +20,8 @@ use snarkvm::prelude::{Program, ProgramID};
 
 use super::*;
 
-use leo_package::{NetworkName, ProgramData};
+use leo_ast::NetworkName;
+use leo_package::ProgramData;
 use leo_span::Symbol;
 
 use ureq::Response;

--- a/leo/cli/commands/debug.rs
+++ b/leo/cli/commands/debug.rs
@@ -116,10 +116,20 @@ fn handle_debug(command: &LeoDebug, context: Context, package: Option<Package>) 
             })
             .collect();
 
+        // Get the network from the package environment.
+        let network = package.env.network;
+
         // No need to keep this around while the interpreter runs.
         std::mem::drop(package);
 
-        leo_interpreter::interpret(&local_dependency_paths, &aleo_paths, address, command.block_height, command.tui)
+        leo_interpreter::interpret(
+            &local_dependency_paths,
+            &aleo_paths,
+            address,
+            command.block_height,
+            command.tui,
+            network,
+        )
     } else {
         let private_key: PrivateKey<TestnetV0> = PrivateKey::from_str(leo_package::TEST_PRIVATE_KEY)?;
         let address = Address::try_from(&private_key)?;
@@ -137,6 +147,13 @@ fn handle_debug(command: &LeoDebug, context: Context, package: Option<Package>) 
             .map(|path_str| path_str.into())
             .collect();
 
-        leo_interpreter::interpret(&leo_paths, &aleo_paths, address, command.block_height, command.tui)
+        leo_interpreter::interpret(
+            &leo_paths,
+            &aleo_paths,
+            address,
+            command.block_height,
+            command.tui,
+            package.map(|p| p.env.network).unwrap_or_default(),
+        )
     }
 }

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -17,7 +17,8 @@
 use super::*;
 
 use check_transaction::TransactionStatus;
-use leo_package::{Manifest, NetworkName, Package, UpgradeConfig, fetch_program_from_network};
+use leo_ast::NetworkName;
+use leo_package::{Manifest, Package, UpgradeConfig, fetch_program_from_network};
 
 #[cfg(not(feature = "only_testnet"))]
 use snarkvm::prelude::{CanaryV0, MainnetV0};

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -350,7 +350,7 @@ fn handle_execute<A: Aleo>(
         }
         let fee_id = fee.id().to_string();
         let id = transaction.id().to_string();
-        let height_before = crate::cli::check_transaction::current_height(&endpoint, network)?;
+        let height_before = check_transaction::current_height(&endpoint, network)?;
         // Broadcast the transaction to the network.
         let response =
             handle_broadcast(&format!("{}/{}/transaction/broadcast", endpoint, network), &transaction, &program_name)?;
@@ -362,7 +362,7 @@ fn handle_execute<A: Aleo>(
 
         match response.status() {
             200 => {
-                let status = crate::cli::check_transaction::check_transaction_with_message(
+                let status = check_transaction::check_transaction_with_message(
                     &id,
                     Some(&fee_id),
                     &endpoint,
@@ -372,11 +372,7 @@ fn handle_execute<A: Aleo>(
                     command.extra.blocks_to_check,
                 )?;
                 if status == Some(TransactionStatus::Accepted) {
-                    println!(
-                        "✅ Successfully broadcast execution with:\n  - transaction ID: '{}'\n  - fee ID: '{}'",
-                        id.bold().yellow(),
-                        fee_id.bold().yellow()
-                    );
+                    println!("✅ Execution confirmed!");
                 }
             }
             _ => {

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -17,7 +17,8 @@
 use super::*;
 
 use check_transaction::TransactionStatus;
-use leo_package::{NetworkName, Package, ProgramData};
+use leo_ast::NetworkName;
+use leo_package::{Package, ProgramData};
 
 use aleo_std::StorageMode;
 use clap::Parser;

--- a/leo/cli/commands/new.rs
+++ b/leo/cli/commands/new.rs
@@ -16,7 +16,8 @@
 
 use super::*;
 
-use leo_package::{NetworkName, Package};
+use leo_ast::NetworkName;
+use leo_package::Package;
 
 /// Create new Leo project
 #[derive(Parser, Debug)]

--- a/leo/cli/commands/query/mod.rs
+++ b/leo/cli/commands/query/mod.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use leo_ast::NetworkName;
 use leo_errors::UtilError;
-use leo_package::{NetworkName, fetch_from_network, verify_valid_program};
+use leo_package::{fetch_from_network, verify_valid_program};
 
 use super::*;
 

--- a/leo/cli/commands/run.rs
+++ b/leo/cli/commands/run.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-use leo_package::NetworkName;
+use leo_ast::NetworkName;
 use snarkvm::{
     cli::Run as SnarkVMRun,
     prelude::{CanaryV0, MainnetV0, Network, Parser as SnarkVMParser, TestnetV0},

--- a/leo/cli/commands/test.rs
+++ b/leo/cli/commands/test.rs
@@ -108,8 +108,14 @@ fn handle_test(command: LeoTest, context: Context, package: Package) -> Result<(
         })
         .collect();
 
-    let (native_test_functions, interpreter_result) =
-        leo_interpreter::find_and_run_tests(&leo_paths, &aleo_paths, address, 0u32, &command.test_name)?;
+    let (native_test_functions, interpreter_result) = leo_interpreter::find_and_run_tests(
+        &leo_paths,
+        &aleo_paths,
+        address,
+        0u32,
+        &command.test_name,
+        package.env.network,
+    )?;
 
     // Now for native tests.
 

--- a/leo/cli/commands/upgrade.rs
+++ b/leo/cli/commands/upgrade.rs
@@ -16,7 +16,8 @@
 
 use super::*;
 
-use leo_package::{NetworkName, Package, fetch_program_from_network};
+use leo_ast::NetworkName;
+use leo_package::{Package, fetch_program_from_network};
 
 #[cfg(not(feature = "only_testnet"))]
 use snarkvm::prelude::{CanaryV0, MainnetV0};

--- a/leo/cli/helpers/check_transaction.rs
+++ b/leo/cli/helpers/check_transaction.rs
@@ -141,7 +141,7 @@ fn check_transaction(
 ) -> Result<CheckedTransaction> {
     // It appears that the default rate limit for snarkOS is 10 requests per second per IP,
     // and this value seems to avoid rate limits in practice, so let's go with this.
-    const DELAY_MILLIS: u64 = 101;
+    const DELAY_MILLIS: u64 = 201;
 
     for use_height in start_height..start_height + blocks_to_check {
         let status = status_at_height(id, maybe_fee_id, endpoint, network, use_height, max_wait)?;
@@ -167,7 +167,7 @@ pub fn check_transaction_with_message(
     max_wait: usize,
     blocks_to_check: usize,
 ) -> Result<Option<TransactionStatus>> {
-    println!("Searching up to {blocks_to_check} blocks to find transaction (this may take several seconds)...");
+    println!("🔄 Searching up to {blocks_to_check} blocks to confirm transaction (this may take several seconds)...");
     let checked = crate::cli::check_transaction::check_transaction(
         id,
         maybe_fee_id,
@@ -182,7 +182,7 @@ pub fn check_transaction_with_message(
         Some(TransactionStatus::Accepted) => println!("Transaction accepted."),
         Some(TransactionStatus::Rejected) => println!("Transaction rejected."),
         Some(TransactionStatus::Aborted) => println!("Transaction aborted."),
-        None => println!("Couldn't find the transaction."),
+        None => println!("Could not find the transaction."),
     }
     Ok(checked.status)
 }

--- a/leo/cli/helpers/check_transaction.rs
+++ b/leo/cli/helpers/check_transaction.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use leo_ast::NetworkName;
 use leo_errors::Result;
-use leo_package::NetworkName;
 
 use anyhow::anyhow;
 use serde::Deserialize;

--- a/leo/package/src/lib.rs
+++ b/leo/package/src/lib.rs
@@ -42,7 +42,8 @@
 //! Such a directory structure, together with a `.gitignore` file, may be created
 //! on the file system using `Package::initialize`.
 //! ```no_run
-//! # use leo_package::{NetworkName, Package};
+//! # use leo_ast::NetworkName;
+//! # use leo_package::{Package};
 //! let path = Package::initialize("my_package", "path/to/parent", NetworkName::TestnetV0, "http://localhost:3030").unwrap();
 //! ```
 //!
@@ -68,6 +69,7 @@
 
 #![forbid(unsafe_code)]
 
+use leo_ast::NetworkName;
 use leo_errors::{PackageError, Result, UtilError};
 use leo_span::Symbol;
 
@@ -84,9 +86,6 @@ pub use location::*;
 
 mod manifest;
 pub use manifest::*;
-
-mod network_name;
-pub use network_name::*;
 
 mod package;
 pub use package::*;

--- a/tests/expectations/compiler/array/bad_array_length_fail.out
+++ b/tests/expectations/compiler/array/bad_array_length_fail.out
@@ -3,7 +3,7 @@ Error [ETYC0372008]: The value 111111111111111 is not a valid `u8`
      |
    3 |         let a: [u32; 111111111111111u8] = [1u32]; // overflow
      |                      ^^^^^^^^^^^^^^^^^
-Error [ETYC0372144]: An array length must be small enough to fit in a `u32` 
+Error [ETYC0372145]: An array length must be small enough to fit in a `u32` 
     --> compiler-test:3:9
      |
    3 |         let a: [u32; 111111111111111u8] = [1u32]; // overflow
@@ -13,7 +13,7 @@ Error [ETYC0372008]: The value 111111111111111 is not a valid `u32`
      |
    4 |         let b: [u32; 111111111111111] = [1u32]; // overflow
      |                      ^^^^^^^^^^^^^^^
-Error [ETYC0372144]: An array length must be small enough to fit in a `u32` 
+Error [ETYC0372145]: An array length must be small enough to fit in a `u32` 
     --> compiler-test:4:9
      |
    4 |         let b: [u32; 111111111111111] = [1u32]; // overflow

--- a/tests/expectations/compiler/constructor/admin_constructor_with_bad_address.out
+++ b/tests/expectations/compiler/constructor/admin_constructor_with_bad_address.out
@@ -1,4 +1,4 @@
-Error [ESAZ0374011]: 'aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzpx' is not a valid address: Invalid account address length: found 61, expected 63
+Error [ESAZ0374011]: 'aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzpx' is not a valid address for the current network: testnet
     --> compiler-test:8:5
      |
    8 |     async constructor() {

--- a/tests/expectations/compiler/statements/assign_external_record_fail.out
+++ b/tests/expectations/compiler/statements/assign_external_record_fail.out
@@ -4,37 +4,22 @@ Error [ETYC0372137]: Cannot assign to the external record type `test0.aleo/R` in
   12 |             r1 = test0.aleo/foo();
      |             ^^
      |
-<<<<<<< HEAD
-     = External record variables may not be assigned to in narrower conditonal scopes than they were defined.
-Error [ETYC0372138]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
-=======
      = External record variables may not be assigned to in narrower conditional scopes than they were defined.
-Error [ETYC0372137]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
->>>>>>> mainnet
+Error [ETYC0372138]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
     --> compiler-test:21:13
      |
   21 |             tupl.0 = test0.aleo/foo();
      |             ^^^^
      |
-<<<<<<< HEAD
-     = Tuples containing external records may not be assigned to in narrower conditonal scopes than they were defined.
-Error [ETYC0372138]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
-=======
      = Tuples containing external records may not be assigned to in narrower conditional scopes than they were defined.
-Error [ETYC0372137]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
->>>>>>> mainnet
+Error [ETYC0372138]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
     --> compiler-test:25:13
      |
   25 |             tupl = (test0.aleo/foo(), test0.aleo/foo());
      |             ^^^^
      |
-<<<<<<< HEAD
-     = Tuples containing external records may not be assigned to in narrower conditonal scopes than they were defined.
-Error [ETYC0372136]: Cannot assign to a member of the external record `test0.aleo/R`.
-=======
      = Tuples containing external records may not be assigned to in narrower conditional scopes than they were defined.
-Error [ETYC0372135]: Cannot assign to a member of the external record `test0.aleo/R`.
->>>>>>> mainnet
+Error [ETYC0372136]: Cannot assign to a member of the external record `test0.aleo/R`.
     --> compiler-test:33:9
      |
   33 |         r.x = x;


### PR DESCRIPTION
This PR removes the `Network` parameter from the compiler, reducing the amount of code that is duplicated by monomorphization.