### PR TITLE
fix: create registry cache directory if it doesn't exist

### DIFF
--- a/leo/package/src/program.rs
+++ b/leo/package/src/program.rs
@@ -134,6 +134,13 @@ impl Program {
     ) -> Result<Self> {
         // It's not a local program; let's check the cache.
         let cache_directory = home_path.join(format!("registry/{network}"));
+        if !cache_directory.exists() {
+            // Create directory if it doesn't exist.
+            std::fs::create_dir_all(&cache_directory).map_err(|err| {
+                UtilError::util_file_io_error(format!("Could not write path {}", cache_directory.display()), err)
+            })?;
+        }
+
         let full_cache_path = cache_directory.join(format!("{name}.aleo"));
 
         // Get the existing bytecode if the file exists.


### PR DESCRIPTION
## Motivation


The directory `~/.aleo/registry/testnet/` is used to store files downloaded from the Aleo network. When Aleo programs with dependencies are built, they attempt to fetch and store these dependencies in the registry directory. If `~/.aleo/registry/testnet/` does not exist, the process fails to store the fetched programs, resulting in build failures for any project with dependencies. This PR ensures the required registry directory exists, preventing such failures and improving the robustness and developer experience of Aleo projects relying on external packages.

I use `~/.aleo/registry/testnet/` because I am using the testnet network. 

The error:
```
Error [EUTL03710000]: File system io error: Could not open file `~/.aleo/registry/testnet/dependency.aleo`. Error: No such file or directory (os error 2)
```