### PR TITLE
[WIP] Cache queries for consistent state paths.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ dependencies = [
  "aleo-std",
  "ansi_term",
  "anyhow",
+ "async-trait",
  "backtrace",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1149,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1729,6 +1741,7 @@ dependencies = [
  "dialoguer",
  "dotenvy",
  "dunce",
+ "futures",
  "indexmap",
  "itertools 0.13.0",
  "leo-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,3 +365,4 @@ inherits = "test"
 incremental = false
 debug = false
 [dependencies]
+async-trait = "0.1.88"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,3 +366,4 @@ incremental = false
 debug = false
 [dependencies]
 async-trait = "0.1.88"
+futures = "0.3.31"

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -255,7 +255,7 @@ fn handle_deploy<N: Network>(
     vm.process().write().add_programs_with_editions(&programs_and_editions)?;
 
     // Specify the query
-    let query = SnarkVMQuery::<N, BlockMemory<N>>::from(&endpoint);
+    let query = CachedQuery::new(SnarkVMQuery::<N, BlockMemory<N>>::from(&endpoint));
 
     // For each of the programs, generate a deployment transaction.
     let mut transactions = Vec::new();

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -307,7 +307,7 @@ fn handle_execute<A: Aleo>(
     let vm = VM::from(ConsensusStore::<A::Network, ConsensusMemory<A::Network>>::open(StorageMode::Production)?)?;
 
     // Specify the query
-    let query = SnarkVMQuery::<A::Network, BlockMemory<A::Network>>::from(&endpoint);
+    let query = CachedQuery::new(SnarkVMQuery::<A::Network, BlockMemory<A::Network>>::from(&endpoint));
 
     // If the program is not local, then download it and its dependencies for the network.
     // Note: The dependencies are downloaded in "post-order" (child before parent).

--- a/leo/cli/commands/upgrade.rs
+++ b/leo/cli/commands/upgrade.rs
@@ -278,7 +278,7 @@ fn handle_upgrade<N: Network>(
     println!();
 
     // Specify the query
-    let query = SnarkVMQuery::<N, BlockMemory<N>>::from(&endpoint);
+    let query = CachedQuery::new(SnarkVMQuery::<N, BlockMemory<N>>::from(&endpoint));
 
     // For each of the programs, generate a deployment transaction.
     let mut transactions = Vec::new();


### PR DESCRIPTION
This PR introduces the `CachedQuery` object. This is used instead of `snarkVM::Query` to fix an issue in retrieving consistent state paths during execution.

During `leo execute` the CLI will attempt to fetch state paths for all input records such that they all have the same global state root. If they do not, the CLI tells users to try again.



