### PR TITLE
[Feature] Support release selection via `leo update`.

### DIFF
--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -98,6 +98,16 @@ fn handle_build(command: &LeoBuild, context: Context, network: NetworkName) -> R
         )?
     };
 
+    // Check the manifest for the compiler version.
+    // If it does not match, warn the user and continue.
+    if package.manifest.leo != env!("CARGO_PKG_VERSION") {
+        tracing::warn!(
+            "The Leo compiler version in the manifest ({}) does not match the current version ({}).",
+            package.manifest.leo,
+            env!("CARGO_PKG_VERSION")
+        );
+    }
+
     let outputs_directory = package.outputs_directory();
     let build_directory = package.build_directory();
     let imports_directory = package.imports_directory();
@@ -163,6 +173,7 @@ fn handle_build(command: &LeoBuild, context: Context, network: NetworkName) -> R
         version: "0.1.0".to_string(),
         description: String::new(),
         license: String::new(),
+        leo: env!("CARGO_PKG_VERSION").to_string(),
         dependencies: None,
         dev_dependencies: None,
     };

--- a/leo/cli/commands/update.rs
+++ b/leo/cli/commands/update.rs
@@ -25,7 +25,7 @@ pub struct LeoUpdate {
     list: bool,
     /// Update to a specific named release
     #[clap(short = 'n', long, help = "An optional release name.")]
-    version: Option<String>,
+    name: Option<String>,
     /// Suppress outputs to terminal
     #[clap(short = 'q', long, help = "Suppress download logs.")]
     quiet: bool,
@@ -53,7 +53,7 @@ impl Command for LeoUpdate {
                 Err(error) => tracing::info!("Failed to list the available versions of Leo\n{error}\n"),
             },
             false => {
-                let result = Updater::update(!self.quiet, self.version);
+                let result = Updater::update(!self.quiet, self.name);
                 if !self.quiet {
                     match result {
                         Ok(status) => {

--- a/leo/cli/commands/update.rs
+++ b/leo/cli/commands/update.rs
@@ -21,10 +21,13 @@ use crate::cli::helpers::updater::Updater;
 #[derive(Debug, Parser)]
 pub struct LeoUpdate {
     /// Lists all available versions of Leo
-    #[clap(short = 'l', long)]
+    #[clap(short = 'l', long, help = "List all available releases.")]
     list: bool,
+    /// Update to a specific named release
+    #[clap(short = 'n', long, help = "An optional release name.")]
+    version: Option<String>,
     /// Suppress outputs to terminal
-    #[clap(short = 'q', long)]
+    #[clap(short = 'q', long, help = "Suppress download logs.")]
     quiet: bool,
 }
 
@@ -50,7 +53,7 @@ impl Command for LeoUpdate {
                 Err(error) => tracing::info!("Failed to list the available versions of Leo\n{error}\n"),
             },
             false => {
-                let result = Updater::update_to_latest_release(!self.quiet);
+                let result = Updater::update(!self.quiet, self.version);
                 if !self.quiet {
                     match result {
                         Ok(status) => {

--- a/leo/cli/helpers/updater.rs
+++ b/leo/cli/helpers/updater.rs
@@ -19,7 +19,7 @@ use leo_errors::{CliError, Result};
 use aleo_std;
 
 use colored::Colorize;
-use self_update::{Status, backends::github, version::bump_is_greater};
+use self_update::{Status, backends::github, get_target, version::bump_is_greater};
 use std::{
     fmt::Write as _,
     fs,
@@ -44,33 +44,42 @@ impl Updater {
         let releases = github::ReleaseList::configure()
             .repo_owner(Self::LEO_REPO_OWNER)
             .repo_name(Self::LEO_REPO_NAME)
+            .with_target(get_target())
             .build()
             .map_err(CliError::self_update_error)?
             .fetch()
             .map_err(CliError::could_not_fetch_versions)?;
 
-        let mut output = "\nList of available versions\n".to_string();
+        let mut output = format!(
+            "\nList of available versions for: {}\nUse the quoted name to select specific releases.\n\n",
+            get_target()
+        );
         for release in releases {
-            let _ = writeln!(output, "  * {}", release.version);
+            let _ = writeln!(output, "  * {} | '{}'", release.version, release.name);
         }
 
         Ok(output)
     }
 
-    /// Update `leo` to the latest release.
-    pub fn update_to_latest_release(show_output: bool) -> Result<Status> {
-        let status = github::Update::configure()
+    /// Update `leo`. If a version is provided, then `leo` is updated to the specific version
+    /// otherwise the update defaults to the latest version.
+    pub fn update(show_output: bool, version: Option<String>) -> Result<Status> {
+        let mut update = github::Update::configure();
+        // Set the defaults.
+        update
             .repo_owner(Self::LEO_REPO_OWNER)
             .repo_name(Self::LEO_REPO_NAME)
             .bin_name(Self::LEO_BIN_NAME)
             .current_version(env!("CARGO_PKG_VERSION"))
             .show_download_progress(show_output)
             .no_confirm(true)
-            .show_output(show_output)
-            .build()
-            .map_err(CliError::self_update_build_error)?
-            .update()
-            .map_err(CliError::self_update_error)?;
+            .show_output(show_output);
+        // Add the version if provided.
+        if let Some(version) = version {
+            update.target_version_tag(&version);
+        }
+        let status =
+            update.build().map_err(CliError::self_update_build_error)?.update().map_err(CliError::self_update_error)?;
 
         Ok(status)
     }

--- a/leo/cli/helpers/updater.rs
+++ b/leo/cli/helpers/updater.rs
@@ -51,7 +51,7 @@ impl Updater {
             .map_err(CliError::could_not_fetch_versions)?;
 
         let mut output = format!(
-            "\nList of available versions for: {}\nUse the quoted name to select specific releases.\n\n",
+            "\nList of available versions for: {}.\nUse the quoted name to select specific releases.\n\n",
             get_target()
         );
         for release in releases {

--- a/leo/package/src/manifest.rs
+++ b/leo/package/src/manifest.rs
@@ -30,6 +30,8 @@ pub struct Manifest {
     pub version: String,
     pub description: String,
     pub license: String,
+    #[serde(default = "current_version")]
+    pub leo: String,
     pub dependencies: Option<Vec<Dependency>>,
     pub dev_dependencies: Option<Vec<Dependency>>,
 }
@@ -57,4 +59,9 @@ impl Manifest {
         serde_json::from_str(&contents)
             .map_err(|err| PackageError::failed_to_deserialize_manifest_file(path.as_ref().display(), err))
     }
+}
+
+// Returns the current version of Leo.
+fn current_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
 }

--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -137,6 +137,7 @@ impl Package {
             version: "0.1.0".to_string(),
             description: String::new(),
             license: "MIT".to_string(),
+            leo: env!("CARGO_PKG_VERSION").to_string(),
             dependencies: None,
             dev_dependencies: None,
         };


### PR DESCRIPTION
This PR,
- supports release selection via `leo update -n <NAME>`
- `leo update` still updates to the latest release. If you select a version that does not have this feature, then you'll need to invoke `leo update` to get it again.
- `leo update -l` also lists the names of the releases, which is used in release selection. Some sample output:
```
> leo update -l
       Leo
List of available versions for: aarch64-apple-darwin
Use the quoted name to select specific releases.
  * 3.1.0 | 'v3.1.0'
  * 3.0.0 | 'v3.0.0'
  * 2.7.3 | 'v2.7.3'
  * 2.7.2 | 'v2.7.2'
  * 2.7.1 | 'v2.7.1'
  * 2.7.0 | 'v2.7.0'
  * 2.6.1 | 'v2.6.1'

```
