### PR TITLE
Improve shadowing error messages with multi-span support

### DIFF
--- a/compiler/passes/src/symbol_table_creation/mod.rs
+++ b/compiler/passes/src/symbol_table_creation/mod.rs
@@ -33,7 +33,7 @@ use leo_ast::{
     Type,
     Variant,
 };
-use leo_errors::{AstError, LeoError, Result};
+use leo_errors::Result;
 use leo_span::Symbol;
 
 use indexmap::IndexSet;
@@ -140,8 +140,9 @@ impl ProgramVisitor for SymbolTableCreationVisitor<'_> {
         // Allow up to one local redefinition for each external struct.
         let full_name = self.module.iter().cloned().chain(std::iter::once(input.name())).collect::<Vec<Symbol>>();
 
-        if !input.is_record && !self.structs.insert(full_name.clone()) {
-            return self.state.handler.emit_err::<LeoError>(AstError::shadowed_struct(input.name(), input.span).into());
+        // duplicate struct checking is handled by insert_struct below via check_shadow_global
+        if !input.is_record {
+            self.structs.insert(full_name.clone());
         }
         if input.is_record {
             // While records are not allowed in submodules, we stll use their full name in the records table.

--- a/compiler/passes/src/type_checking/program.rs
+++ b/compiler/passes/src/type_checking/program.rs
@@ -19,11 +19,11 @@ use crate::{VariableSymbol, VariableType};
 
 use leo_ast::{DiGraphError, Type, *};
 use leo_errors::TypeCheckerError;
-use leo_span::{Symbol, sym};
+use leo_span::{Span, Symbol, sym};
 
 use itertools::Itertools;
 use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 
 impl ProgramVisitor for TypeCheckingVisitor<'_> {
     fn visit_program(&mut self, input: &Program) {
@@ -224,17 +224,31 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
         });
 
         // Check for conflicting struct/record member names.
-        let mut used = HashSet::new();
+        let mut used: HashMap<Symbol, Span> = HashMap::new();
         for Member { identifier, type_, span, .. } in &input.members {
             // Check that the member types are defined.
             self.assert_type_is_valid(type_, *span);
 
-            if !used.insert(identifier.name) {
+            if let Some(first_span) = used.get(&identifier.name) {
                 self.emit_err(if input.is_record {
-                    TypeCheckerError::duplicate_record_variable(input.name(), *span)
+                    TypeCheckerError::duplicate_record_variable_multi_span(
+                        input.name(),
+                        identifier.name,
+                        *span,
+                        Some(format!("`{}` redefined here", identifier.name)),
+                        vec![(*first_span, format!("previous definition of the variable `{}` here", identifier.name))],
+                    )
                 } else {
-                    TypeCheckerError::duplicate_struct_member(input.name(), *span)
+                    TypeCheckerError::duplicate_struct_member_multi_span(
+                        input.name(),
+                        identifier.name,
+                        *span,
+                        Some(format!("`{}` redefined here", identifier.name)),
+                        vec![(*first_span, format!("previous definition of the member `{}` here", identifier.name))],
+                    )
                 });
+            } else {
+                used.insert(identifier.name, *span);
             }
         }
 

--- a/errors/src/common/macros.rs
+++ b/errors/src/common/macros.rs
@@ -137,4 +137,27 @@ macro_rules! create_messages {
         // Steps the code value by one and calls on the rest of the functions.
         create_messages!(@step $code + 1i32, $(($(#[$docs])* $formatted_or_backtraced_tail, $names($($tail_arg_names: $tail_arg_types,)*), $messages, $helps),)*);
     };
+    // matches the function if it is a formatted message with multiple spans.
+    (@step $code:expr, ($(#[$error_func_docs:meta])* formatted_multi_span, $name:ident($($arg_names:ident: $arg_types:ty,)*), $message:expr, $help:expr), $(($(#[$docs:meta])* $formatted_or_backtraced_tail:ident, $names:ident($($tail_arg_names:ident: $tail_arg_types:ty,)*), $messages:expr, $helps:expr),)*) => {
+        $(#[$error_func_docs])*
+        pub fn $name($($arg_names: $arg_types,)* span: leo_span::Span, span_label: Option<String>, additional_spans: Vec<(leo_span::Span, String)>) -> Self {
+            Self::Formatted(
+                Formatted::new_from_spans(
+                    $message,
+                    $help,
+                    $code + Self::code_mask(),
+                    Self::code_identifier(),
+                    Self::message_type(),
+                    Self::is_error(),
+                    span,
+                    span_label,
+                    additional_spans,
+                    Backtrace::new(),
+                )
+            )
+        }
+
+        // Steps the code value by one and calls on the rest of the functions.
+        create_messages!(@step $code + 1i32, $(($(#[$docs])* $formatted_or_backtraced_tail, $names($($tail_arg_names: $tail_arg_types,)*), $messages, $helps),)*);
+    };
 }

--- a/errors/src/errors/ast/ast_errors.rs
+++ b/errors/src/errors/ast/ast_errors.rs
@@ -74,38 +74,6 @@ create_messages!(
         help: None,
     }
 
-    /// For when a user shadows a function.
-    @formatted
-    shadowed_function {
-        args: (func: impl Display),
-        msg: format!("function `{func}` shadowed by"),
-        help: None,
-    }
-
-    /// For when a user shadows a struct.
-    @formatted
-    shadowed_struct {
-        args: (struct_: impl Display),
-        msg: format!("struct `{struct_}` shadowed by"),
-        help: None,
-    }
-
-    /// For when a user shadows a record.
-    @formatted
-    shadowed_record {
-        args: (record: impl Display),
-        msg: format!("record `{record}` shadowed by"),
-        help: None,
-    }
-
-    /// For when a user shadows a variable.
-    @formatted
-    shadowed_variable {
-        args: (var: impl Display),
-        msg: format!("variable `{var}` shadowed by"),
-        help: None,
-    }
-
     /// For when the symbol table fails to be represented as a JSON string.
     @backtraced
     failed_to_convert_symbol_table_to_json_string {
@@ -158,5 +126,13 @@ create_messages!(
         args: (func: impl Display),
         msg: format!("function `{func}` not found"),
         help: None,
+    }
+
+    /// For when a user shadows a type.
+    @formatted_multi_span
+    shadowed_variable_multi_span {
+        args: (type_: impl Display, var: impl Display),
+        msg: format!("the {type_} `{var}` is being shadowed."),
+        help: Some("names must be unique within their scope".to_string()),
     }
 );

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -193,6 +193,26 @@ create_messages!(
         help: None,
     }
 
+    /// Attempted to define more that one struct member with the same name (with multiple spans).
+    @formatted_multi_span
+    duplicate_struct_member_multi_span {
+        args: (struct_: impl Display, member_name: impl Display),
+        msg: format!(
+            "the name `{member_name}` is defined multiple times in struct `{struct_}`"
+        ),
+        help: Some(format!("struct members must have unique names")),
+    }
+
+    /// Attempted to define more that one record variable with the same name (with multiple spans).
+    @formatted_multi_span
+    duplicate_record_variable_multi_span {
+        args: (record: impl Display, variable_name: impl Display),
+        msg: format!(
+            "the name `{variable_name}` is defined multiple times in record `{record}`"
+        ),
+        help: Some(format!("record variables must have unique names")),
+    }
+
     /// Attempted to access an invalid struct.
     @formatted
     undefined_type {

--- a/tests/expectations/compiler/const_generics/const_generic_shadowing_fail.out
+++ b/tests/expectations/compiler/const_generics/const_generic_shadowing_fail.out
@@ -1,0 +1,9 @@
+Error [EAST0372013]: the global constant `N` is being shadowed.
+    --> compiler-test:8:18
+     |
+   7 |     const N: u32 = 5;
+     |           ^ previous definition of the global constant `N` here
+   8 |     inline foo::[N: u32]() {}
+     |                  ^ `N` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/const_generics/const_generic_shadows_global_constant_fail.out
+++ b/tests/expectations/compiler/const_generics/const_generic_shadows_global_constant_fail.out
@@ -1,0 +1,9 @@
+Error [EAST0372013]: the global constant `N` is being shadowed.
+    --> compiler-test:7:18
+     |
+   6 |     const N: u32 = 5;
+     |           ^ previous definition of the global constant `N` here
+   7 |     inline foo::[N: u32]() {}
+     |                  ^ `N` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/const_generics/const_generic_shadows_param_fail.out
+++ b/tests/expectations/compiler/const_generics/const_generic_shadows_param_fail.out
@@ -1,0 +1,9 @@
+Error [EAST0372013]: the const generic parameter `N` is being shadowed.
+    --> compiler-test:6:26
+     |
+   6 |     inline foo::[N: u32](N: u32) -> u32 {
+     |                  ^ previous definition of the const generic parameter `N` here
+   6 |     inline foo::[N: u32](N: u32) -> u32 {
+     |                          ^ `N` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/const_generics/local_shadows_const_generic_fail.out
+++ b/tests/expectations/compiler/const_generics/local_shadows_const_generic_fail.out
@@ -1,0 +1,9 @@
+Error [EAST0372013]: the const generic parameter `N` is being shadowed.
+    --> compiler-test:7:13
+     |
+   6 |     inline foo::[N: u32]() -> u32 {
+     |                  ^ previous definition of the const generic parameter `N` here
+   7 |         let N: u32 = 10u32;
+     |             ^ `N` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/constants/duplicate_global_constant_fail.out
+++ b/tests/expectations/compiler/constants/duplicate_global_constant_fail.out
@@ -1,0 +1,9 @@
+Error [EAST0372013]: the global constant `MAX` is being shadowed.
+    --> compiler-test:3:11
+     |
+   2 |     const MAX: u32 = 100;
+     |           ^^^ previous definition of the global constant `MAX` here
+   3 |     const MAX: u32 = 200;
+     |           ^^^ `MAX` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/constants/local_const_shadows_global_fail.out
+++ b/tests/expectations/compiler/constants/local_const_shadows_global_fail.out
@@ -1,0 +1,10 @@
+Error [EAST0372013]: the global constant `VALUE` is being shadowed.
+    --> compiler-test:5:15
+     |
+   2 |     const VALUE: u32 = 10;
+     |           ^^^^^ previous definition of the global constant `VALUE` here
+     ...
+   5 |         const VALUE: u32 = 20;
+     |               ^^^^^ `VALUE` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/function/duplicate_function_name_fail.out
+++ b/tests/expectations/compiler/function/duplicate_function_name_fail.out
@@ -1,0 +1,14 @@
+Error [EAST0372013]: the function `foo` is being shadowed.
+    --> compiler-test:10:5
+     |
+   6 |     function foo() -> u32 {
+        return 1u32;
+    }
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ previous definition of the function `foo` here
+     ...
+  10 |     function foo() -> u32 {
+        return 2u32;
+    }
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `foo` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/records/duplicate_record_name_fail.out
+++ b/tests/expectations/compiler/records/duplicate_record_name_fail.out
@@ -1,0 +1,16 @@
+Error [EAST0372013]: the record `Token` is being shadowed.
+    --> compiler-test:7:5
+     |
+   2 |     record Token {
+        owner: address,
+        amount: u64,
+    }
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ previous definition of the record `Token` here
+     ...
+   7 |     record Token {
+        owner: address,
+        balance: u64,
+    }
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Token` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/records/duplicate_var_fail.out
+++ b/tests/expectations/compiler/records/duplicate_var_fail.out
@@ -1,9 +1,43 @@
-Error [ETYC0372016]: Record Token defined with more than one variable with the same name.
-    --> compiler-test:7:9
+Error [ETYC0372018]: the name `owner` is defined multiple times in record `Token`
+    --> compiler-test:6:9
      |
-   7 |         owner: address, // Cannot define two record variables with the same name.
-     |         ^^^^^^^^^^^^^^
-Error [ETYC0372083]: A program must have at least one transition function.
+   5 |         owner: address,
+     |         ^^^^^^^^^^^^^^ previous definition of the variable `owner` here
+   6 |         owner: address, // Cannot define two record variables with the same name.
+     |         ^^^^^^^^^^^^^^ `owner` redefined here
+     |
+     = record variables must have unique names
+Error [ETYC0372018]: the name `owner` is defined multiple times in record `Asset`
+    --> compiler-test:15:9
+     |
+  12 |         owner: address,
+     |         ^^^^^^^^^^^^^^ previous definition of the variable `owner` here
+     ...
+  15 |         owner: address,
+     |         ^^^^^^^^^^^^^^ `owner` redefined here
+     |
+     = record variables must have unique names
+Error [ETYC0372018]: the name `owner` is defined multiple times in record `Data`
+    --> compiler-test:22:9
+     |
+  20 |         owner: address,
+     |         ^^^^^^^^^^^^^^ previous definition of the variable `owner` here
+     ...
+  22 |         owner: address,
+     |         ^^^^^^^^^^^^^^ `owner` redefined here
+     |
+     = record variables must have unique names
+Error [ETYC0372018]: the name `amount` is defined multiple times in record `Data`
+    --> compiler-test:23:9
+     |
+  21 |         amount: u64,
+     |         ^^^^^^^^^^^ previous definition of the variable `amount` here
+     ...
+  23 |         amount: u64,
+     |         ^^^^^^^^^^^ `amount` redefined here
+     |
+     = record variables must have unique names
+Error [ETYC0372085]: A program must have at least one transition function.
     --> compiler-test:2:9
      |
    2 | program test.aleo {

--- a/tests/expectations/compiler/statements/duplicate_variable.out
+++ b/tests/expectations/compiler/statements/duplicate_variable.out
@@ -3,7 +3,7 @@ Error [EAST0372009]: variable `x` shadowed by
      |
    5 |       	let x: bool = true;
      |            ^
-Error [ETYC0372083]: A program must have at least one transition function.
+Error [ETYC0372085]: A program must have at least one transition function.
     --> compiler-test:2:9
      |
    2 | program test.aleo {

--- a/tests/expectations/compiler/statements/variable_shadows_input_param_fail.out
+++ b/tests/expectations/compiler/statements/variable_shadows_input_param_fail.out
@@ -1,0 +1,9 @@
+Error [EAST0372013]: the input parameter `x` is being shadowed.
+    --> compiler-test:3:13
+     |
+   2 |     transition main(x: u32) -> u32 {
+     |                     ^ previous definition of the input parameter `x` here
+   3 |         let x: u32 = 10u32;
+     |             ^ `x` redefined here
+     |
+     = names must be unique within their scope

--- a/tests/expectations/compiler/structs/duplicate_struct_name_fail.out
+++ b/tests/expectations/compiler/structs/duplicate_struct_name_fail.out
@@ -1,0 +1,13 @@
+Error [EAST0372011]: There are two definitions of struct `Point` that do not match.
+    --> compiler-test:2:5
+     |
+   2 |     struct Point {
+     |     ^^^^^^^^^^^^^^
+   3 |         x: u32,
+     |         ^^^^^^^
+   4 |         y: u32,
+     |         ^^^^^^^
+   5 |     }
+     |     ^
+     |
+     = Check the import files to see if there are any struct definitions of the same name.

--- a/tests/expectations/compiler/structs/duplicate_struct_variable.out
+++ b/tests/expectations/compiler/structs/duplicate_struct_variable.out
@@ -1,9 +1,53 @@
-Error [ETYC0372015]: Struct Bar defined with more than one member with the same name.
-    --> compiler-test:5:9
+Error [ETYC0372017]: the name `x` is defined multiple times in struct `Bar`
+    --> compiler-test:6:9
      |
    5 |         x: u32,
-     |         ^^^^^^
-Error [ETYC0372083]: A program must have at least one transition function.
+     |         ^^^^^^ previous definition of the member `x` here
+   6 |         x: u32,
+     |         ^^^^^^ `x` redefined here
+     |
+     = struct members must have unique names
+Error [ETYC0372017]: the name `name` is defined multiple times in struct `Person`
+    --> compiler-test:14:9
+     |
+  11 |         name: field,
+     |         ^^^^^^^^^^^ previous definition of the member `name` here
+     ...
+  14 |         name: field,
+     |         ^^^^^^^^^^^ `name` redefined here
+     |
+     = struct members must have unique names
+Error [ETYC0372017]: the name `id` is defined multiple times in struct `Data`
+    --> compiler-test:21:9
+     |
+  19 |         id: u32,
+     |         ^^^^^^^ previous definition of the member `id` here
+     ...
+  21 |         id: u32,
+     |         ^^^^^^^ `id` redefined here
+     |
+     = struct members must have unique names
+Error [ETYC0372017]: the name `value` is defined multiple times in struct `Data`
+    --> compiler-test:22:9
+     |
+  20 |         value: u64,
+     |         ^^^^^^^^^^ previous definition of the member `value` here
+     ...
+  22 |         value: u64,
+     |         ^^^^^^^^^^ `value` redefined here
+     |
+     = struct members must have unique names
+Error [ETYC0372017]: the name `host` is defined multiple times in struct `Config`
+    --> compiler-test:36:9
+     |
+  27 |         host: field,
+     |         ^^^^^^^^^^^ previous definition of the member `host` here
+     ...
+  36 |         host: field,
+     |         ^^^^^^^^^^^ `host` redefined here
+     |
+     = struct members must have unique names
+Error [ETYC0372085]: A program must have at least one transition function.
     --> compiler-test:2:9
      |
    2 | program test.aleo {

--- a/tests/tests/compiler/const_generics/const_generic_shadowing_fail.leo
+++ b/tests/tests/compiler/const_generics/const_generic_shadowing_fail.leo
@@ -1,0 +1,10 @@
+
+program test.aleo {
+    transition main() -> u32 {
+        return 0u32; 
+    }
+
+    const N: u32 = 5;
+    inline foo::[N: u32]() {}
+}
+

--- a/tests/tests/compiler/const_generics/const_generic_shadows_global_constant_fail.leo
+++ b/tests/tests/compiler/const_generics/const_generic_shadows_global_constant_fail.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    transition main() -> u32 {
+        return 0u32; 
+    }
+
+    const N: u32 = 5;
+    inline foo::[N: u32]() {}
+}
+

--- a/tests/tests/compiler/const_generics/const_generic_shadows_param_fail.leo
+++ b/tests/tests/compiler/const_generics/const_generic_shadows_param_fail.leo
@@ -1,0 +1,10 @@
+program test.aleo {
+    transition main() -> u32 {
+        return 0u32; 
+    }
+
+    inline foo::[N: u32](N: u32) -> u32 {
+        return N;
+    }
+}
+

--- a/tests/tests/compiler/const_generics/local_shadows_const_generic_fail.leo
+++ b/tests/tests/compiler/const_generics/local_shadows_const_generic_fail.leo
@@ -1,0 +1,11 @@
+program test.aleo {
+    transition main() -> u32 {
+        return 0u32; 
+    }
+
+    inline foo::[N: u32]() -> u32 {
+        let N: u32 = 10u32;
+        return N;
+    }
+}
+

--- a/tests/tests/compiler/constants/duplicate_global_constant_fail.leo
+++ b/tests/tests/compiler/constants/duplicate_global_constant_fail.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    const MAX: u32 = 100;
+    const MAX: u32 = 200;
+
+    transition main() -> u32 {
+        return MAX;
+    }
+}
+

--- a/tests/tests/compiler/constants/local_const_shadows_global_fail.leo
+++ b/tests/tests/compiler/constants/local_const_shadows_global_fail.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    const VALUE: u32 = 10;
+
+    transition main() -> u32 {
+        const VALUE: u32 = 20;
+        return VALUE;
+    }
+}
+

--- a/tests/tests/compiler/function/duplicate_function_name_fail.leo
+++ b/tests/tests/compiler/function/duplicate_function_name_fail.leo
@@ -1,0 +1,14 @@
+program test.aleo {
+    transition main() -> u32 {
+        return 0u32; 
+    }
+
+    function foo() -> u32 {
+        return 1u32;
+    }
+
+    function foo() -> u32 {
+        return 2u32;
+    }
+}
+

--- a/tests/tests/compiler/records/duplicate_record_name_fail.leo
+++ b/tests/tests/compiler/records/duplicate_record_name_fail.leo
@@ -1,0 +1,16 @@
+program test.aleo {
+    record Token {
+        owner: address,
+        amount: u64,
+    }
+
+    record Token {
+        owner: address,
+        balance: u64,
+    }
+
+    transition main() -> u32 {
+        return 0u32;
+    }
+}
+

--- a/tests/tests/compiler/records/duplicate_var_fail.leo
+++ b/tests/tests/compiler/records/duplicate_var_fail.leo
@@ -1,11 +1,25 @@
 
 program test.aleo {
+    // test 1: adjacent duplicate - no "..." gap marker
     record Token {
-        // The token owner.
         owner: address,
-        // The token owner.
         owner: address, // Cannot define two record variables with the same name.
-        // The token amount.
+        amount: u64,
+    }
+
+    // test 2: duplicate with gap - "..." marker
+    record Asset {
+        owner: address,
+        value: u64,
+        description: field,
+        owner: address,
+    }
+
+    // test 3: multiple different duplicates
+    record Data {
+        owner: address,
+        amount: u64,
+        owner: address,
         amount: u64,
     }
 

--- a/tests/tests/compiler/statements/variable_shadows_input_param_fail.leo
+++ b/tests/tests/compiler/statements/variable_shadows_input_param_fail.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    transition main(x: u32) -> u32 {
+        let x: u32 = 10u32;
+        return x;
+    }
+}
+

--- a/tests/tests/compiler/structs/duplicate_struct_name_fail.leo
+++ b/tests/tests/compiler/structs/duplicate_struct_name_fail.leo
@@ -1,0 +1,16 @@
+program test.aleo {
+    struct Point {
+        x: u32,
+        y: u32,
+    }
+
+    struct Point {
+        a: u32,
+        b: u32,
+    }
+
+    transition main() -> u32 {
+        return 0u32;
+    }
+}
+

--- a/tests/tests/compiler/structs/duplicate_struct_variable.leo
+++ b/tests/tests/compiler/structs/duplicate_struct_variable.leo
@@ -1,8 +1,39 @@
 
 program test.aleo {
+    // test 1: adjacent duplicate - no gap marker
     struct Bar {
         x: u32,
         x: u32,
+    }
+
+    // test 2: duplicate with gap marker - "..."
+    struct Person {
+        name: field,
+        age: u8,
+        city: field,
+        name: field,
+    }
+
+    // test 3: multiple different duplicates
+    struct Data {
+        id: u32,
+        value: u64,
+        id: u32,
+        value: u64,
+    }
+
+    // test 4: large gap between duplicates
+    struct Config {
+        host: field,
+        port: u16,
+        protocol: field,
+        timeout: u32,
+        retry_count: u8,
+        max_connections: u32,
+        buffer_size: u64,
+        compression: bool,
+        encryption: bool,
+        host: field,
     }
 
     function main(zz: bool) -> bool {


### PR DESCRIPTION
Currently we only have information about a variable being shadowed and the variable that it shadows it, but this is confusing for the user as they don't see where is the variable that is being shadowed in the error message.

So, this adds multi-span error reporting, as previous commits for structs and records, reusing the same logic that was added.

For a program:
```
program test.aleo {
    transition main() -> u32 {
        return 0u32; 
    }

    const N: u32 = 5;
    inline foo::[N: u32]() {}
}
```

Before:

```
|Error [EAST0372009]: variable `N` shadowed by
    --> /Users/mohammadfawaz/Desktop/bugs/b28668/src/main.leo:8:18
     |
   8 |     inline foo::[N: u32]() {}
     |                  ^
     ```

After: 
```
Error [EAST0372013]: the global constant `N` is being shadowed.
    --> \\?\C:\Users\tetektoza\source\repos\leo\bug_demo\const_generic_shadowing\src\main.leo:7:18
     |
   6 |     const N: u32 = 5;
     |           ^ previous definition of the global constant `N` here
   7 |     inline foo::[N: u32]() {}
     |                  ^ `N` redefined here
     |
     = names must be unique within their scope
```

**The same has been done for const generics, local variables, duplicate function params, etc.**


@mohammadfawaz Sorry, couldn't hold myself from doing that for shadowing as well. It may look like a lot of lines, but this is rebased on top of https://github.com/ProvableHQ/leo/pull/28893, so it has to be merged first.

Resolves: https://github.com/ProvableHQ/leo/issues/28706