### PR TITLE
Allow selecting the Leo add verification network

### DIFF
--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -317,16 +317,160 @@ mod tests {
         commands::LeoNew,
         run_with_args,
     };
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use leo_ast::NetworkName;
     use leo_span::create_session_if_not_set_then;
     use serial_test::serial;
     use std::env::temp_dir;
 
+    #[test]
+    fn add_onchain_source_and_network_target_parse_separately() {
+        for args in [
+            ["leo", "add", "--network", "mainnet", "--onchain", "credits"],
+            ["leo", "add", "--network", "mainnet", "-n", "credits"],
+            ["leo", "add", "credits", "--onchain", "--network", "mainnet"],
+        ] {
+            let cli = CLI::try_parse_from(args).expect("an on-chain source and explicit network should parse");
+            let Commands::Add { command } = cli.command else { panic!("expected `leo add`") };
+            assert!(command.source.onchain);
+            assert_eq!(command.env_override.network, Some(NetworkName::MainnetV0));
+        }
+
+        let cli = CLI::try_parse_from(["leo", "add", "credits", "--onchain"])
+            .expect("`--onchain` should retain environment/default network fallback");
+        let Commands::Add { command } = cli.command else { panic!("expected `leo add`") };
+        assert!(command.source.onchain);
+        assert_eq!(command.env_override.network, None);
+
+        let cli = CLI::try_parse_from(["leo", "add", "--network", "mainnet", "--edition", "3", "credits"])
+            .expect("an edition source and explicit network should parse");
+        let Commands::Add { command } = cli.command else { panic!("expected `leo add`") };
+        assert!(!command.source.onchain);
+        assert_eq!(command.source.edition, Some(3));
+        assert_eq!(command.env_override.network, Some(NetworkName::MainnetV0));
+
+        for args in [
+            vec!["leo", "add", "--network", "mainnet", "credits"],
+            vec!["leo", "add", "--network"],
+            vec!["leo", "add", "--network", "unknown", "--onchain", "credits"],
+            vec!["leo", "add", "credits", "--onchain", "--edition", "3"],
+            vec!["leo", "add", "credits", "--onchain", "--local", "../credits"],
+        ] {
+            assert!(CLI::try_parse_from(args).is_err());
+        }
+    }
+
+    #[test]
+    fn add_help_describes_shared_network_options() {
+        let mut command = CLI::command();
+        let help = command
+            .find_subcommand_mut("add")
+            .expect("`leo` should provide an `add` subcommand")
+            .render_long_help()
+            .to_string();
+
+        assert!(help.contains("The network endpoint to use."));
+        assert!(help.contains("`mainnet`, `testnet`, and `canary`."));
+    }
+
+    // A cache hit in only the explicitly selected network proves that the CLI value reaches
+    // `CompilationUnit::fetch`, rather than only the parser or outer error message.
+    #[test]
+    #[serial]
+    fn add_explicit_network_selects_matching_cache() {
+        let temp_dir = temp_dir();
+        let project_directory = temp_dir.join("add_explicit_network");
+        let home = temp_dir.join(".aleo_add_explicit_network");
+        for path in [&project_directory, &home] {
+            if path.exists() {
+                std::fs::remove_dir_all(path).unwrap();
+            }
+        }
+
+        let new = CLI {
+            debug: false,
+            quiet: true,
+            json_output: None,
+            disable_update_check: true,
+            command: Commands::New {
+                command: LeoNew { name: "add_explicit_network".to_string(), library: false, workspace: false },
+            },
+            path: Some(project_directory.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(new).expect("failed to create the test package");
+
+            dotenvy::dotenv().ok();
+            let implicit_network = crate::cli::commands::get_network(&None).unwrap_or(NetworkName::TestnetV0);
+            let explicit_network = if implicit_network == NetworkName::MainnetV0 {
+                NetworkName::TestnetV0
+            } else {
+                NetworkName::MainnetV0
+            };
+
+            let dependency = "network_override";
+            let cache_directory = home.join("registry").join(explicit_network.to_string()).join(dependency).join("0");
+            std::fs::create_dir_all(&cache_directory).unwrap();
+            std::fs::write(
+                cache_directory.join(format!("{dependency}.aleo")),
+                format!(
+                    "program {dependency}.aleo;\n\nfunction main:\n    input r0 as u32.public;\n    input r1 as u32.private;\n    add r0 r1 into r2;\n    output r2 as u32.private;\n"
+                ),
+            )
+            .unwrap();
+
+            let add = CLI {
+                debug: false,
+                quiet: true,
+                json_output: None,
+                disable_update_check: true,
+                command: Commands::Add {
+                    command: LeoAdd {
+                        name: dependency.to_string(),
+                        source: DependencySource {
+                            local: None,
+                            onchain: true,
+                            edition: None,
+                            workspace: false,
+                            git: None,
+                        },
+                        git_ref: GitRef { branch: None, tag: None, rev: None },
+                        env_override: crate::cli::commands::EnvOptions {
+                            network: Some(explicit_network),
+                            endpoint: Some("http://localhost:1".to_string()),
+                            network_retries: 0,
+                        },
+                        dev: false,
+                    },
+                },
+                path: Some(project_directory.clone()),
+                home: Some(home.clone()),
+                package: None,
+            };
+
+            run_with_args(add).expect("the explicit network should select its matching cached program");
+
+            let manifest =
+                leo_package::Manifest::read_from_file(project_directory.join(leo_package::MANIFEST_FILENAME)).unwrap();
+            let dependencies = manifest.dependencies.as_ref().expect("the dependency should be recorded");
+            assert_eq!(dependencies.len(), 1);
+            let dependency = dependencies.iter().next().unwrap();
+            assert_eq!(dependency.name, "network_override.aleo");
+            assert_eq!(dependency.location, leo_package::Location::Network);
+            assert_eq!(dependency.edition, None);
+        });
+
+        let _ = std::fs::remove_dir_all(project_directory);
+        let _ = std::fs::remove_dir_all(home);
+    }
+
     // An unreachable endpoint with no retries stands in for a program that isn't on the network.
     #[test]
     #[serial]
-    fn add_network_dependency_rejects_missing_program() {
+    fn add_onchain_dependency_rejects_missing_program() {
         let temp_dir = temp_dir();
         let project_directory = temp_dir.join("add_missing_network_dep");
         if project_directory.exists() {
@@ -354,10 +498,13 @@ mod tests {
             command: Commands::Add {
                 command: LeoAdd {
                     name: "nonexistent_program".to_string(),
-                    source: DependencySource { local: None, network: true, edition: None, workspace: false, git: None },
+                    source: DependencySource { local: None, onchain: true, edition: None, workspace: false, git: None },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: Some("http://localhost:1".to_string()),
-                    network_retries: 0,
+                    env_override: crate::cli::commands::EnvOptions {
+                        network: None,
+                        endpoint: Some("http://localhost:1".to_string()),
+                        network_retries: 0,
+                    },
                     dev: false,
                 },
             },
@@ -1875,7 +2022,7 @@ function external_nested_function:
         // Overwrite `src/main.leo` file
         std::fs::write(project_directory.join("src").join("main.leo"), program_str).unwrap();
 
-        // Cache the program before the add: `leo add --network` verifies existence by fetching,
+        // Cache the program before the add: `leo add --onchain` verifies existence by fetching,
         // and a cached copy satisfies that check offline.
         let registry = temp_dir.join(".aleo").join("registry").join("testnet");
         std::fs::create_dir_all(&registry).unwrap();
@@ -1903,14 +2050,13 @@ function external_nested_function:
                     name: "nested_example_layer_0".to_string(),
                     source: DependencySource {
                         local: None,
-                        network: true,
+                        onchain: false,
                         edition: Some(0),
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },
@@ -2021,14 +2167,13 @@ program child.aleo {
                     name: "parent".to_string(),
                     source: DependencySource {
                         local: Some(parent_directory.clone()),
-                        network: false,
+                        onchain: false,
                         edition: None,
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },
@@ -2047,14 +2192,13 @@ program child.aleo {
                     name: "child".to_string(),
                     source: DependencySource {
                         local: Some(child_directory.clone()),
-                        network: false,
+                        onchain: false,
                         edition: None,
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },
@@ -2073,14 +2217,13 @@ program child.aleo {
                     name: "child".to_string(),
                     source: DependencySource {
                         local: Some(child_directory.clone()),
-                        network: false,
+                        onchain: false,
                         edition: None,
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },
@@ -2230,14 +2373,13 @@ program inner_2.aleo {
                     name: "inner_1".to_string(),
                     source: DependencySource {
                         local: Some(inner_1_directory.clone()),
-                        network: false,
+                        onchain: false,
                         edition: None,
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },
@@ -2256,14 +2398,13 @@ program inner_2.aleo {
                     name: "inner_2".to_string(),
                     source: DependencySource {
                         local: Some(inner_2_directory.clone()),
-                        network: false,
+                        onchain: false,
                         edition: None,
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },
@@ -2448,14 +2589,13 @@ program inner_2.aleo {
                     name: "inner_1".to_string(),
                     source: DependencySource {
                         local: Some(inner_1_directory.clone()),
-                        network: false,
+                        onchain: false,
                         edition: None,
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },
@@ -2474,14 +2614,13 @@ program inner_2.aleo {
                     name: "inner_2".to_string(),
                     source: DependencySource {
                         local: Some(inner_2_directory.clone()),
-                        network: false,
+                        onchain: false,
                         edition: None,
                         workspace: false,
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
-                    endpoint: None,
-                    network_retries: 2,
+                    env_override: Default::default(),
                     dev: false,
                 },
             },

--- a/crates/leo/src/cli/commands/add.rs
+++ b/crates/leo/src/cli/commands/add.rs
@@ -33,19 +33,8 @@ pub struct LeoAdd {
     #[clap(flatten)]
     pub(crate) git_ref: GitRef,
 
-    #[clap(
-        long,
-        help = "Endpoint used to verify a network dependency exists. Overrides the `ENDPOINT` environment variable."
-    )]
-    pub(crate) endpoint: Option<String>,
-
-    #[clap(
-        long,
-        env = "NETWORK_RETRIES",
-        help = "Number of times to retry a failed network request when verifying a network dependency.",
-        default_value = "2"
-    )]
-    pub(crate) network_retries: u32,
+    #[clap(flatten)]
+    pub(crate) env_override: EnvOptions,
 
     #[clap(long, help = "This is a development dependency.", default_value = "false")]
     pub(crate) dev: bool,
@@ -62,8 +51,8 @@ pub struct DependencySource {
     )]
     pub(crate) local: Option<PathBuf>,
 
-    #[clap(short = 'n', long, help = "Whether the dependency is on a live network.", group = "source")]
-    pub(crate) network: bool,
+    #[clap(short = 'n', long = "onchain", help = "Use a program deployed on-chain.", group = "source")]
+    pub(crate) onchain: bool,
 
     #[clap(
         short = 'e',
@@ -238,13 +227,11 @@ impl Command for LeoAdd {
             let name = normalize_program_name(&self.name)?;
 
             // Verify the program exists before recording it, reusing the build's fetch path.
-            // Network/endpoint default like `build`; the name comes from the env because
-            // `--network` here selects the source rather than a network name.
-            let network = get_network(&None).unwrap_or_else(|_| {
+            let network = get_network(&self.env_override.network).unwrap_or_else(|_| {
                 tracing::warn!("⚠️ No network specified, defaulting to 'testnet'.");
                 NetworkName::TestnetV0
             });
-            let endpoint = get_endpoint(&self.endpoint).unwrap_or_else(|_| {
+            let endpoint = get_endpoint(&self.env_override.endpoint).unwrap_or_else(|_| {
                 tracing::warn!("⚠️ No endpoint specified, defaulting to '{DEFAULT_ENDPOINT}'.");
                 DEFAULT_ENDPOINT.to_string()
             });
@@ -256,7 +243,7 @@ impl Command for LeoAdd {
                 network,
                 &endpoint,
                 false,
-                self.network_retries,
+                self.env_override.network_retries,
             )
             .map_err(|err| {
                 crate::errors::custom(format!(

--- a/crates/leo/src/cli/commands/common/options.rs
+++ b/crates/leo/src/cli/commands/common/options.rs
@@ -56,13 +56,13 @@ pub struct BuildOptions {
 pub struct EnvOptions {
     #[clap(
         long,
-        help = "The network type to use. e.g `mainnet`, `testnet, and `canary`. Overrides the `NETWORK` environment variable in your shell or `.env` file.",
+        help = "The network type to use, e.g. `mainnet`, `testnet`, and `canary`. Overrides the `NETWORK` environment variable in your shell or `.env` file.",
         global = true
     )]
     pub(crate) network: Option<NetworkName>,
     #[clap(
         long,
-        help = "The endpoint to deploy to. Overrides the `ENDPOINT` environment variable. We recommend using `https://api.explorer.provable.com/v1` for live networks and `http://localhost:3030` for local devnets.",
+        help = "The network endpoint to use. Overrides the `ENDPOINT` environment variable. We recommend using `https://api.explorer.provable.com/v1` for live networks and `http://localhost:3030` for local devnets.",
         global = true
     )]
     pub(crate) endpoint: Option<String>,

--- a/documentation/cli/add.md
+++ b/documentation/cli/add.md
@@ -20,13 +20,13 @@ leo add --local <LOCAL> <NAME>
 
 where `<NAME>` is the name of the imported program or library, and `<LOCAL>` is the path to the local project or library.
 
-To add a program already deployed onchain as a dependency to your project, run the following command:
+To add a program already deployed on-chain as a dependency to your project, run the following command:
 
 ```bash
-leo add <NAME> --network
+leo add <NAME> --onchain
 ```
 
-`<NAME>` is the name of the imported program. Leo makes sure that the program exists before it changes `program.json`.
+where `<NAME>` is the name of the imported program. To select the verification network explicitly, use `leo add <NAME> --onchain --network <NETWORK>`. If neither `--network` nor `NETWORK` is set, Leo uses `testnet`.
 
 To add another member of the enclosing workspace as a dependency:
 
@@ -56,11 +56,15 @@ Libraries can only be added as local or git dependencies. Use `--local` or `--gi
 
 Specifies a local program or library dependency at `<LOCAL>`. The path can be a Leo project root, a Leo library root, or a compiled `.aleo` file.
 
-### `--network`
+### `--onchain`
 
 ### `-n`
 
-Specifies that the dependency to be added is a remote program currently deployed onchain. The network that it will be pulled from will be the same as the one specified in by the `NETWORK` variable in `.env`
+Specifies that the dependency is a program deployed on-chain. Leo verifies that the program exists before it changes `program.json`.
+
+### `--network <NETWORK>`
+
+Specifies the network that Leo uses to verify and fetch an on-chain dependency. This option overrides the `NETWORK` environment variable. If neither is set, Leo uses `testnet`. Leo also uses the selected network for cache lookup and does not store it in `program.json`.
 
 ### `--endpoint <ENDPOINT>`
 
@@ -90,7 +94,7 @@ Pin a git dependency to a specific branch, tag, or revision. These require `--gi
 
 ### `-e <EDITION>`
 
-Specifies the expected edition of the program being imported. Only passing this flag will assume that the program is being imported from the network.
+Specifies the expected edition of an on-chain program. This option selects the on-chain source by itself, so do not combine it with `--onchain`. You can combine it with `--network <NETWORK>`.
 
 :::warning
 Do not use this feature unless you know what you are doing!

--- a/documentation/guides/dependencies.md
+++ b/documentation/guides/dependencies.md
@@ -28,22 +28,22 @@ See [Leo Libraries](../language/libraries.md) for details on how to write and us
 To add a program already deployed on the Aleo network as a dependency:
 
 ```bash
-leo add credits.aleo --network
+leo add credits.aleo --onchain
 ```
 
 or
 
 ```bash
-leo add credits --network
+leo add credits --onchain
 ```
 
-For mainnet dependencies:
+To verify against mainnet instead of the environment or the default `testnet` network:
 
 ```bash
-NETWORK=mainnet leo add credits --network
+leo add credits --onchain --network mainnet
 ```
 
-You can also set `NETWORK=mainnet` in `.env`. If you do not use `--endpoint`, Leo uses `ENDPOINT` from the environment. Leo makes sure that the program exists on the selected network before it changes `program.json`. Use `--network-retries` to set the number of retries.
+An explicit `--network` value overrides the `NETWORK` environment variable. If neither is set, Leo uses `testnet`. Leo uses this network for verification, cache lookup, and fetching before it changes `program.json`. The selected network is not stored in the manifest. Later commands resolve their network independently. The `--endpoint` option overrides `ENDPOINT`, and `--network-retries` controls retries for network requests.
 
 This adds an entry to your `program.json`:
 
@@ -57,8 +57,8 @@ This adds an entry to your `program.json`:
     {
       "name": "credits.aleo",
       "location": "network",
-      "network": "testnet",
-      "path": null
+      "path": null,
+      "edition": null
     }
   ]
 }
@@ -80,8 +80,8 @@ This records the path in `program.json`:
     {
       "name": "my_library.aleo",
       "location": "local",
-      "network": null,
-      "path": "./path/to/my_library"
+      "path": "./path/to/my_library",
+      "edition": null
     }
   ]
 }
@@ -171,12 +171,12 @@ Tests can already use `dependencies`. Thus, put a library that `src` and tests u
 
 This reference applies to each dependency kind, not only workspace members. `leo add` completes these fields. If you edit `program.json` manually, Leo validates each dependency when it loads the manifest. Leo rejects incompatible field combinations. Each entry has a `location`, and the other fields depend on it:
 
-| `location`  | `path`      | `edition`   | `network`            |
-| ----------- | ----------- | ----------- | -------------------- |
-| `network`   | not allowed | optional    | target network       |
-| `local`     | required    | not allowed | —                    |
-| `workspace` | not allowed | not allowed | —                    |
-| `git`       | not allowed | not allowed | —                    |
+| `location`  | `path`      | `edition`   |
+| ----------- | ----------- | ----------- |
+| `network`   | not allowed | optional    |
+| `local`     | required    | not allowed |
+| `workspace` | not allowed | not allowed |
+| `git`       | not allowed | not allowed |
 
 The same rules apply to entries in `dev_dependencies`. `workspace` entries are looked up in `workspace.json` and resolved to a local path automatically. `git` entries additionally take a `git` object with a `url` and at most one of `branch`/`tag`/`rev`.
 
@@ -252,7 +252,6 @@ This records the pinned edition in the manifest:
 {
   "name": "some_program.aleo",
   "location": "network",
-  "network": "testnet",
   "path": null,
   "edition": 3
 }

--- a/tests/expectations/cli/test_add/COMMANDS
+++ b/tests/expectations/cli/test_add/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} --disable-update-check add --network credits.aleo --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+${LEO_BIN} --disable-update-check add --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --onchain credits.aleo
 
 ${LEO_BIN} --disable-update-check build
 

--- a/tests/expectations/cli/test_add_dependency/COMMANDS
+++ b/tests/expectations/cli/test_add_dependency/COMMANDS
@@ -10,12 +10,12 @@ echo "no source exit code: $?"
 cat program.json
 
 echo "--- 2. leo add with multiple flags (should fail) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add some_dep --network --local ../some_path
+${LEO_BIN} --disable-update-check add some_dep --onchain --local ../some_path
 echo "multiple flags exit code: $?"
 cat program.json
 
-echo "--- 3. leo add --network (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+echo "--- 3. leo add --onchain --network testnet (should succeed) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} credits --onchain --network testnet
 cat program.json
 
 echo "--- 4. leo add --local (should succeed) ---" | tee /dev/stderr
@@ -31,12 +31,12 @@ ${LEO_BIN} --disable-update-check add credits --local ../credits
 cat program.json
 
 echo "--- 7. leo add --dev for a program not on the network (should fail) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --dev --network dev_dep --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+${LEO_BIN} --disable-update-check add --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --dev --onchain dev_dep
 echo "missing network dep exit code: $?"
 cat program.json
 
 echo "--- 8. leo add --dev for a program on the network (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --dev --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+${LEO_BIN} --disable-update-check add --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --dev -n credits
 echo "network dev dep exit code: $?"
 cat program.json
 

--- a/tests/expectations/cli/test_add_dependency/STDERR
+++ b/tests/expectations/cli/test_add_dependency/STDERR
@@ -1,18 +1,17 @@
 --- 1. leo add with no source flag (should fail) ---
 error: the following required arguments were not provided:
-  <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git <GIT>>
+  <--local <LOCAL>|--onchain|--edition <EDITION>|--workspace|--git <GIT>>
 
-Usage: leo add <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
+Usage: leo add <--local <LOCAL>|--onchain|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
 
 For more information, try '--help'.
 --- 2. leo add with multiple flags (should fail) ---
-error: the argument '--network' cannot be used with '--local <LOCAL>'
+error: the argument '--onchain' cannot be used with '--local <LOCAL>'
 
-Usage: leo add <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
+Usage: leo add <--local <LOCAL>|--onchain|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
 
 For more information, try '--help'.
---- 3. leo add --network (should succeed) ---
-       Leo ⚠️ No network specified, defaulting to 'testnet'.
+--- 3. leo add --onchain --network testnet (should succeed) ---
 --- 4. leo add --local (should succeed) ---
 Error [ECLI0377045]: Could not read `../some_local/program.json` — is `../some_local` a valid Leo package?
 
@@ -21,13 +20,11 @@ Error [ECLI0377045]: Could not read `../some_local/program.json` — is `../some
 Error [ECLI0377045]: Could not read `../credits/program.json` — is `../credits` a valid Leo package?
 
 --- 7. leo add --dev for a program not on the network (should fail) ---
-       Leo ⚠️ No network specified, defaulting to 'testnet'.
 Error [ECLI0377045]: Could not find program `dev_dep.aleo` on network `testnet` at `http://localhost:3030`: Error [EPAK0375067]: network request to `http://localhost:3030/testnet/program/dev_dep.aleo/latest_edition` failed with status `500 Internal Server Error`
      |
      = Verify that `--network` and `--endpoint` point to a running node and that you have connectivity.
 
 --- 8. leo add --dev for a program on the network (should succeed) ---
-       Leo ⚠️ No network specified, defaulting to 'testnet'.
 --- 9. leo remove library dep by bare name (should succeed) ---
        Leo ✅ Successfully removed the local dependency my_lib with path ../my_lib.
 --- 10. leo remove program dep by bare name (should succeed) ---

--- a/tests/expectations/cli/test_add_dependency/STDOUT
+++ b/tests/expectations/cli/test_add_dependency/STDOUT
@@ -18,7 +18,7 @@ multiple flags exit code: 2
   "dependencies": null,
   "dev_dependencies": null
 }
---- 3. leo add --network (should succeed) ---
+--- 3. leo add --onchain --network testnet (should succeed) ---
        Leo ✅ Added network dependency `credits.aleo`.
 {
   "program": "my_program.aleo",

--- a/tests/expectations/cli/test_git_dependency/COMMANDS
+++ b/tests/expectations/cli/test_git_dependency/COMMANDS
@@ -94,8 +94,8 @@ echo "--- 6. multiple git references (should fail) ---" | tee /dev/stderr
 leo_redacted add gitlib --git "${URL}" --branch main --tag v1
 echo "exit: $?"
 
-echo "--- 7. --git combined with --network (should fail) ---" | tee /dev/stderr
-leo_redacted add gitlib --git "${URL}" --network
+echo "--- 7. --git combined with --onchain (should fail) ---" | tee /dev/stderr
+leo_redacted add gitlib --git "${URL}" --onchain
 echo "exit: $?"
 
 echo "--- 8. add a library under a name ending in .aleo (should fail) ---" | tee /dev/stderr

--- a/tests/expectations/cli/test_git_dependency/STDERR
+++ b/tests/expectations/cli/test_git_dependency/STDERR
@@ -5,21 +5,21 @@
 --- 4b. build --offline reuses the lock and cache ---
 --- 5. --branch without --git (should fail) ---
 error: the following required arguments were not provided:
-  <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git <GIT>>
+  <--local <LOCAL>|--onchain|--edition <EDITION>|--workspace|--git <GIT>>
 
-Usage: leo add --branch <BRANCH> <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
+Usage: leo add --branch <BRANCH> <--local <LOCAL>|--onchain|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
 
 For more information, try '--help'.
 --- 6. multiple git references (should fail) ---
 error: the argument '--branch <BRANCH>' cannot be used with '--tag <TAG>'
 
-Usage: leo add --branch <BRANCH> <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
+Usage: leo add --branch <BRANCH> <--local <LOCAL>|--onchain|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
 
 For more information, try '--help'.
---- 7. --git combined with --network (should fail) ---
-error: the argument '--git <GIT>' cannot be used with '--network'
+--- 7. --git combined with --onchain (should fail) ---
+error: the argument '--git <GIT>' cannot be used with '--onchain'
 
-Usage: leo add <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
+Usage: leo add <--local <LOCAL>|--onchain|--edition <EDITION>|--workspace|--git <GIT>> <NAME>
 
 For more information, try '--help'.
 --- 8. add a library under a name ending in .aleo (should fail) ---

--- a/tests/expectations/cli/test_git_dependency/STDOUT
+++ b/tests/expectations/cli/test_git_dependency/STDOUT
@@ -125,7 +125,7 @@ offline build exit: 0
 exit: 2
 --- 6. multiple git references (should fail) ---
 exit: 2
---- 7. --git combined with --network (should fail) ---
+--- 7. --git combined with --onchain (should fail) ---
 exit: 2
 --- 8. add a library under a name ending in .aleo (should fail) ---
 exit: 213

--- a/tests/expectations/cli/test_library/COMMANDS
+++ b/tests/expectations/cli/test_library/COMMANDS
@@ -7,8 +7,8 @@ cd top_lib || exit 1
 echo "--- leo add --local (should succeed) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check add base_lib --local ../base_lib
 
-echo "--- leo add --network on a library (should fail) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add credits --network
+echo "--- leo add --onchain on a library (should fail) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add credits --onchain
 echo "add network to library exit code: $?"
 
 echo "--- leo build (should succeed) ---" | tee /dev/stderr

--- a/tests/expectations/cli/test_library/STDERR
+++ b/tests/expectations/cli/test_library/STDERR
@@ -1,5 +1,5 @@
 --- leo add --local (should succeed) ---
---- leo add --network on a library (should fail) ---
+--- leo add --onchain on a library (should fail) ---
 Error [ECLI0377045]: A library package can only depend on other libraries. Use `--local <path>` to add a library dependency.
 
 --- leo build (should succeed) ---

--- a/tests/expectations/cli/test_library/STDOUT
+++ b/tests/expectations/cli/test_library/STDOUT
@@ -1,6 +1,6 @@
 --- leo add --local (should succeed) ---
        Leo ✅ Added local dependency `base_lib` at path `../base_lib`.
---- leo add --network on a library (should fail) ---
+--- leo add --onchain on a library (should fail) ---
 add network to library exit code: 213
 --- leo build (should succeed) ---
 ⚠️ No network specified, defaulting to 'testnet'.

--- a/tests/expectations/cli/test_network_retries_flag/COMMANDS
+++ b/tests/expectations/cli/test_network_retries_flag/COMMANDS
@@ -5,7 +5,7 @@
 
 LEO_BIN=${1}
 
-for cmd in build run execute deploy upgrade query synthesize; do
+for cmd in add build run execute deploy upgrade query synthesize; do
     if ${LEO_BIN} --disable-update-check "${cmd}" --help 2>&1 | grep -qF -- '--network-retries'; then
         echo "${cmd}: --network-retries OK"
     else

--- a/tests/expectations/cli/test_network_retries_flag/STDOUT
+++ b/tests/expectations/cli/test_network_retries_flag/STDOUT
@@ -1,3 +1,4 @@
+add: --network-retries OK
 build: --network-retries OK
 run: --network-retries OK
 execute: --network-retries OK

--- a/tests/tests/cli/test_add/COMMANDS
+++ b/tests/tests/cli/test_add/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} --disable-update-check add --network credits.aleo --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+${LEO_BIN} --disable-update-check add --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --onchain credits.aleo
 
 ${LEO_BIN} --disable-update-check build
 

--- a/tests/tests/cli/test_add_dependency/COMMANDS
+++ b/tests/tests/cli/test_add_dependency/COMMANDS
@@ -10,12 +10,12 @@ echo "no source exit code: $?"
 cat program.json
 
 echo "--- 2. leo add with multiple flags (should fail) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add some_dep --network --local ../some_path
+${LEO_BIN} --disable-update-check add some_dep --onchain --local ../some_path
 echo "multiple flags exit code: $?"
 cat program.json
 
-echo "--- 3. leo add --network (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+echo "--- 3. leo add --onchain --network testnet (should succeed) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} credits --onchain --network testnet
 cat program.json
 
 echo "--- 4. leo add --local (should succeed) ---" | tee /dev/stderr
@@ -31,12 +31,12 @@ ${LEO_BIN} --disable-update-check add credits --local ../credits
 cat program.json
 
 echo "--- 7. leo add --dev for a program not on the network (should fail) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --dev --network dev_dep --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+${LEO_BIN} --disable-update-check add --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --dev --onchain dev_dep
 echo "missing network dep exit code: $?"
 cat program.json
 
 echo "--- 8. leo add --dev for a program on the network (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --dev --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+${LEO_BIN} --disable-update-check add --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --dev -n credits
 echo "network dev dep exit code: $?"
 cat program.json
 

--- a/tests/tests/cli/test_git_dependency/COMMANDS
+++ b/tests/tests/cli/test_git_dependency/COMMANDS
@@ -94,8 +94,8 @@ echo "--- 6. multiple git references (should fail) ---" | tee /dev/stderr
 leo_redacted add gitlib --git "${URL}" --branch main --tag v1
 echo "exit: $?"
 
-echo "--- 7. --git combined with --network (should fail) ---" | tee /dev/stderr
-leo_redacted add gitlib --git "${URL}" --network
+echo "--- 7. --git combined with --onchain (should fail) ---" | tee /dev/stderr
+leo_redacted add gitlib --git "${URL}" --onchain
 echo "exit: $?"
 
 echo "--- 8. add a library under a name ending in .aleo (should fail) ---" | tee /dev/stderr

--- a/tests/tests/cli/test_library/COMMANDS
+++ b/tests/tests/cli/test_library/COMMANDS
@@ -7,8 +7,8 @@ cd top_lib || exit 1
 echo "--- leo add --local (should succeed) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check add base_lib --local ../base_lib
 
-echo "--- leo add --network on a library (should fail) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add credits --network
+echo "--- leo add --onchain on a library (should fail) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add credits --onchain
 echo "add network to library exit code: $?"
 
 echo "--- leo build (should succeed) ---" | tee /dev/stderr

--- a/tests/tests/cli/test_network_retries_flag/COMMANDS
+++ b/tests/tests/cli/test_network_retries_flag/COMMANDS
@@ -5,7 +5,7 @@
 
 LEO_BIN=${1}
 
-for cmd in build run execute deploy upgrade query synthesize; do
+for cmd in add build run execute deploy upgrade query synthesize; do
     if ${LEO_BIN} --disable-update-check "${cmd}" --help 2>&1 | grep -qF -- '--network-retries'; then
         echo "${cmd}: --network-retries OK"
     else


### PR DESCRIPTION
## Motivation

Fixes #29591.

`leo add` previously used `--network` as a valueless source selector, so the verification network could only be selected through `NETWORK`. This change separates the source selector from the verification-network override.

`--onchain` replaces the old valueless `--network`; `--network <NETWORK>` now selects the verification network.

## Test Plan

- `cargo +nightly fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets --locked --features only_testnet -- -D warnings` — passed.
- `cargo nextest run --all --locked --cargo-profile ci --features only_testnet --verbose` — passed on Linux, macOS, and Windows in CI.
- Parser, help-text, cache-selection, and CLI integration expectations cover the new `--onchain` / `--network <NETWORK>` behavior.
- Updated `documentation/cli/add.md` and `documentation/guides/dependencies.md`; the selected network remains fetch/cache-only and is not stored in `program.json`.

## Related PRs

None.