### PR TITLE
Fix leo fmt plugin selection for exported declarations

### DIFF
--- a/crates/fmt/tests/source/export_items.leo
+++ b/crates/fmt/tests/source/export_items.leo
@@ -1,0 +1,10 @@
+// Interface comment.
+export interface Example{fn value()->u8;}
+export const VALUE:u8=1u8;export const OTHER:u8=2u8;
+// Generic struct comment.
+export struct Item::[N:u32]{values:[u8;N],}export struct Plain{value:u8,}
+export fn value()->u8{return VALUE;}export fn generic::[N:u32](value:[u8;N])->[u8;N]{return value;}
+export final fn finalize_value(){}export final fn generic_final::[N:u32](value:[u8;N]){}
+export view fn view_value()->u8{return VALUE;}export view fn generic_view::[N:u32](value:[u8;N])->[u8;N]{return value;}
+@no_inline
+export fn annotated_value()->u8{return OTHER;}

--- a/crates/fmt/tests/target/export_items.leo
+++ b/crates/fmt/tests/target/export_items.leo
@@ -1,0 +1,40 @@
+// Interface comment.
+export interface Example {
+    fn value() -> u8;
+}
+
+export const VALUE: u8 = 1u8;
+export const OTHER: u8 = 2u8;
+// Generic struct comment.
+export struct Item::[N: u32] {
+    values: [u8; N],
+}
+
+export struct Plain {
+    value: u8,
+}
+
+export fn value() -> u8 {
+    return VALUE;
+}
+
+export fn generic::[N: u32](value: [u8; N]) -> [u8; N] {
+    return value;
+}
+
+export final fn finalize_value() {}
+
+export final fn generic_final::[N: u32](value: [u8; N]) {}
+
+export view fn view_value() -> u8 {
+    return VALUE;
+}
+
+export view fn generic_view::[N: u32](value: [u8; N]) -> [u8; N] {
+    return value;
+}
+
+@no_inline
+export fn annotated_value() -> u8 {
+    return OTHER;
+}

--- a/crates/leo/src/cli/plugin.rs
+++ b/crates/leo/src/cli/plugin.rs
@@ -26,14 +26,22 @@ use std::{
 
 const PLUGIN_PREFIX: &str = "leo-";
 
-/// Scan `PATH` for an executable named `name`.
+/// Find an executable named `name` next to the current Leo binary or on `PATH`.
 pub fn find_exe(name: &str) -> Option<PathBuf> {
     let filename = format!("{name}{}", std::env::consts::EXE_SUFFIX);
+    if let Some(path) = std::env::current_exe().ok().and_then(|path| find_sibling_exe(&filename, &path)) {
+        return Some(path);
+    }
     let var = std::env::var_os("PATH")?;
     std::env::split_paths(&var).find_map(|dir| {
         let candidate = dir.join(&filename);
         if is_executable(&candidate) { Some(candidate) } else { None }
     })
+}
+
+fn find_sibling_exe(filename: &str, current_exe: &Path) -> Option<PathBuf> {
+    let candidate = current_exe.parent()?.join(filename);
+    is_executable(&candidate).then_some(candidate)
 }
 
 /// Find and execute a plugin binary, forwarding `args` and optionally setting
@@ -133,4 +141,28 @@ fn is_executable(path: &Path) -> bool {
 #[cfg(not(unix))]
 fn is_executable(path: &Path) -> bool {
     path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_sibling_plugin() {
+        let directory = tempfile::tempdir().unwrap();
+        let current_exe = directory.path().join(format!("leo{}", std::env::consts::EXE_SUFFIX));
+        let plugin = directory.path().join(format!("leo-fmt{}", std::env::consts::EXE_SUFFIX));
+        std::fs::write(&current_exe, "").unwrap();
+        std::fs::write(&plugin, "").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&plugin).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&plugin, permissions).unwrap();
+        }
+
+        assert_eq!(find_sibling_exe(plugin.file_name().unwrap().to_str().unwrap(), &current_exe), Some(plugin));
+    }
 }


### PR DESCRIPTION
## Motivation

`leo fmt` can run an old `leo-fmt` executable from `PATH`, even when the current Leo installation contains the matching formatter. An old formatter can move `export` away from a declaration and produce invalid Leo source.

This change makes Leo use the executable next to the current Leo binary before it searches `PATH`. The formatter tests now verify all parser-supported positions for `export`, including interfaces, constants, structs, functions, final functions, view functions, generic declarations, annotated functions, comments, and adjacent declarations.

Closes #29618.

## Test Plan

- `cargo test -p leo-fmt`
- `cargo test -p leo-lang cli::plugin::tests::finds_sibling_plugin`
- Run `leo fmt --check` with an old `leo-fmt` earlier in `PATH`.
- `cargo clippy --workspace --all-targets --all-features`
- `cargo +nightly fmt --all -- --check`

## Related PRs

None.
