### PR TITLE
Fix module-qualified interface records

### DIFF
--- a/crates/ast/src/interface/mod.rs
+++ b/crates/ast/src/interface/mod.rs
@@ -55,7 +55,9 @@ impl Interface {
 
     /// Returns `true` if `ty` resolves to a record declared directly in this interface.
     ///
+    /// `interface_location` must be the canonical location used to retrieve this interface.
     /// Record identity includes the defining program, module path, and record name.
+    /// Inherited record prototypes are not included.
     pub fn is_record_type(&self, ty: &TypeKind, interface_location: &Location) -> bool {
         let TypeKind::Composite(composite) = ty else {
             return false;

--- a/crates/ast/src/interface/mod.rs
+++ b/crates/ast/src/interface/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Identifier, Node, NodeID, TypeKind, indent_display::Indent};
+use crate::{Identifier, Location, Node, NodeID, TypeKind, indent_display::Indent};
 use leo_span::{Span, Symbol};
 use serde::Serialize;
 use std::fmt;
@@ -53,15 +53,23 @@ impl Interface {
         self.identifier.name
     }
 
-    /// Returns `true` if `ty` is a composite type whose name matches a record declared in this interface.
-    pub fn is_record_type(&self, ty: &TypeKind) -> bool {
-        if let TypeKind::Composite(ct) = ty
-            && let Some(loc) = ct.path.try_global_location()
-            && let Some(&name) = loc.path.first()
-        {
-            return self.records.iter().any(|(n, _)| *n == name);
-        }
-        false
+    /// Returns `true` if `ty` resolves to a record declared directly in this interface.
+    ///
+    /// Record identity includes the defining program, module path, and record name.
+    pub fn is_record_type(&self, ty: &TypeKind, interface_location: &Location) -> bool {
+        let TypeKind::Composite(composite) = ty else {
+            return false;
+        };
+        let Some(record_location) = composite.path.try_global_location() else {
+            return false;
+        };
+        let Some(&record_name) = record_location.path.last() else {
+            return false;
+        };
+
+        record_location.program == interface_location.program
+            && record_location.module_path() == interface_location.module_path()
+            && self.records.iter().any(|(name, _)| *name == record_name)
     }
 }
 
@@ -105,3 +113,49 @@ impl fmt::Display for Interface {
 }
 
 crate::simple_node_impl!(Interface);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CompositeType, Path};
+    use leo_span::create_session_if_not_set_then;
+
+    fn composite_type(program: Symbol, path: &[Symbol]) -> TypeKind {
+        let identifier = Identifier::new(*path.last().expect("test paths are non-empty"), NodeID::default());
+        CompositeType {
+            path: Path::new(None, Vec::new(), identifier, Default::default(), NodeID::default())
+                .to_global(Location::new(program, path.to_vec())),
+            const_arguments: Vec::new(),
+        }
+        .into()
+    }
+
+    #[test]
+    fn record_type_matching_uses_complete_location_identity() {
+        create_session_if_not_set_then(|_| {
+            let library = Symbol::intern("ops_lib");
+            let other_library = Symbol::intern("other_lib");
+            let algorithms = Symbol::intern("algorithms");
+            let nested = Symbol::intern("nested");
+            let sibling = Symbol::intern("sibling");
+            let processor = Symbol::intern("Processor");
+            let token = Symbol::intern("Token");
+            let undeclared = Symbol::intern("Undeclared");
+            let interface = Interface { records: vec![(token, RecordPrototype::default())], ..Default::default() };
+
+            let root_interface = Location::new(library, vec![processor]);
+            let module_interface = Location::new(library, vec![algorithms, processor]);
+            let nested_interface = Location::new(library, vec![algorithms, nested, processor]);
+
+            assert!(interface.is_record_type(&composite_type(library, &[token]), &root_interface));
+            assert!(interface.is_record_type(&composite_type(library, &[algorithms, token]), &module_interface));
+            assert!(
+                interface.is_record_type(&composite_type(library, &[algorithms, nested, token]), &nested_interface)
+            );
+            assert!(!interface.is_record_type(&composite_type(other_library, &[algorithms, token]), &module_interface));
+            assert!(!interface.is_record_type(&composite_type(library, &[sibling, token]), &module_interface));
+            assert!(!interface.is_record_type(&composite_type(library, &[algorithms, undeclared]), &module_interface));
+            assert!(!interface.is_record_type(&TypeKind::Boolean, &module_interface));
+        });
+    }
+}

--- a/crates/ast/src/interface/mod.rs
+++ b/crates/ast/src/interface/mod.rs
@@ -56,6 +56,8 @@ impl Interface {
     /// Returns `true` if `ty` resolves to a record declared directly in this interface.
     ///
     /// `interface_location` must be the canonical location used to retrieve this interface.
+    /// This context is required because an `Interface` value does not carry its defining
+    /// program or containing module path.
     /// Record identity includes the defining program, module path, and record name.
     /// Inherited record prototypes are not included.
     pub fn is_record_type(&self, ty: &TypeKind, interface_location: &Location) -> bool {

--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -37,6 +37,7 @@ use leo_ast::{
     IntrinsicExpression,
     Literal,
     LiteralVariant,
+    Location,
     MemberAccess,
     NetworkName,
     Node,
@@ -606,17 +607,19 @@ impl CodeGeneratingVisitor<'_> {
     ///
     /// Panics if the interface type is not a composite or the symbol table entry is missing (both
     /// are guaranteed by the type checker).
-    fn lookup_dynamic_op_interface(&self, input: &DynamicOpExpression) -> Interface {
+    fn lookup_dynamic_op_interface<'a>(&self, input: &'a DynamicOpExpression) -> (&'a Location, Interface) {
         let caller_program = self.program_id.expect("Dynamic ops only appear within programs.").as_symbol();
         let TypeKind::Composite(CompositeType { path: interface_path, .. }) = &input.interface else {
             panic!("Dynamic ops can only be done over interface types, got `{}`", input.interface);
         };
         let interface_location = interface_path.try_global_location().expect("Should be resolved by now.");
-        self.state
+        let interface = self
+            .state
             .symbol_table
             .lookup_interface(caller_program, interface_location)
             .expect("Type checking guarantees interface exists")
-            .clone()
+            .clone();
+        (interface_location, interface)
     }
 
     /// Emits code for the PROG and NET operands shared by all dynamic instructions.
@@ -655,7 +658,7 @@ impl CodeGeneratingVisitor<'_> {
         };
         let op_name = op.name;
 
-        let interface = self.lookup_dynamic_op_interface(input);
+        let (_, interface) = self.lookup_dynamic_op_interface(input);
         let mapping_proto = interface
             .mappings
             .iter()
@@ -695,7 +698,7 @@ impl CodeGeneratingVisitor<'_> {
             panic!("visit_dynamic_function_call expects a DynamicOpKind::Call");
         };
 
-        let interface = self.lookup_dynamic_op_interface(input);
+        let (interface_location, interface) = self.lookup_dynamic_op_interface(input);
 
         let (_, func_proto) = interface
             .functions
@@ -727,7 +730,7 @@ impl CodeGeneratingVisitor<'_> {
             .iter()
             .map(|inp| {
                 let viz = AleoVisibility::maybe_from(inp.mode()).or(Some(AleoVisibility::Private));
-                self.dynamic_call_input_type(inp.type_.kind(), viz, Some(&interface))
+                self.dynamic_call_input_type(inp.type_.kind(), viz, Some((interface_location, &interface)))
             })
             .collect();
 
@@ -747,7 +750,9 @@ impl CodeGeneratingVisitor<'_> {
         let output_types: Vec<(AleoType, Option<AleoVisibility>)> = func_proto
             .output
             .iter()
-            .map(|out| self.dynamic_call_output_type(out.type_.kind(), out.mode, Some(&interface)))
+            .map(|out| {
+                self.dynamic_call_output_type(out.type_.kind(), out.mode, Some((interface_location, &interface)))
+            })
             .collect();
 
         let dest_exprs: Vec<AleoExpr> = destinations.iter().cloned().map(AleoExpr::Reg).collect();

--- a/crates/passes/src/code_generation/type_.rs
+++ b/crates/passes/src/code_generation/type_.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-use leo_ast::{IntegerType, Interface, Mode, TypeKind};
+use leo_ast::{IntegerType, Interface, Location, Mode, TypeKind};
 
 impl CodeGeneratingVisitor<'_> {
     pub fn visit_type(&self, input: &TypeKind) -> AleoType {
@@ -123,9 +123,11 @@ impl CodeGeneratingVisitor<'_> {
         &self,
         type_: &TypeKind,
         visibility: Option<AleoVisibility>,
-        interface: Option<&Interface>,
+        interface_context: Option<(&Location, &Interface)>,
     ) -> (AleoType, Option<AleoVisibility>) {
-        if matches!(type_, TypeKind::DynRecord) || interface.is_some_and(|i| i.is_record_type(type_)) {
+        if matches!(type_, TypeKind::DynRecord)
+            || interface_context.is_some_and(|(location, interface)| interface.is_record_type(type_, location))
+        {
             return (AleoType::DynamicRecord, None);
         }
         (self.visit_type(type_), visibility)
@@ -137,11 +139,13 @@ impl CodeGeneratingVisitor<'_> {
         &self,
         type_: &TypeKind,
         mode: Mode,
-        interface: Option<&Interface>,
+        interface_context: Option<(&Location, &Interface)>,
     ) -> (AleoType, Option<AleoVisibility>) {
         if matches!(type_, TypeKind::Future(..)) {
             (AleoType::DynamicFuture, None)
-        } else if matches!(type_, TypeKind::DynRecord) || interface.is_some_and(|i| i.is_record_type(type_)) {
+        } else if matches!(type_, TypeKind::DynRecord)
+            || interface_context.is_some_and(|(location, interface)| interface.is_record_type(type_, location))
+        {
             (AleoType::DynamicRecord, None)
         } else {
             let viz = AleoVisibility::maybe_from(mode).or(Some(AleoVisibility::Private));

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -1147,7 +1147,9 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
 
         // Dispatch to the appropriate checker based on the kind of dynamic op.
         match &input.kind {
-            DynamicOpKind::Call { .. } => self.check_dynamic_function_call(input, &interface, expected),
+            DynamicOpKind::Call { .. } => {
+                self.check_dynamic_function_call(input, interface_location, &interface, expected)
+            }
             DynamicOpKind::Read { .. } => self.check_dynamic_read(input, &interface, expected),
             DynamicOpKind::Op { .. } => self.check_dynamic_mapping_op(input, &interface, expected),
         }

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -2651,14 +2651,23 @@ impl TypeCheckingVisitor<'_> {
     }
 
     /// Replaces interface record types with `TypeKind::DynRecord`. Only recurses into tuples — records cannot be nested inside structs or arrays.
-    pub fn replace_records_with_dyn_record(&mut self, ty: &TypeKind, interface: &Interface) -> TypeKind {
+    pub fn replace_records_with_dyn_record(
+        &mut self,
+        ty: &TypeKind,
+        interface_location: &Location,
+        interface: &Interface,
+    ) -> TypeKind {
         match ty {
             TypeKind::DynRecord => TypeKind::DynRecord,
             TypeKind::Tuple(tuple) => TypeKind::Tuple(TupleType::new(
-                tuple.elements().iter().map(|t| self.replace_records_with_dyn_record(t, interface)).collect(),
+                tuple
+                    .elements()
+                    .iter()
+                    .map(|element| self.replace_records_with_dyn_record(element, interface_location, interface))
+                    .collect(),
             )),
             other => {
-                if interface.is_record_type(other) {
+                if interface.is_record_type(other, interface_location) {
                     TypeKind::DynRecord
                 } else {
                     other.clone()
@@ -3009,6 +3018,7 @@ impl TypeCheckingVisitor<'_> {
     pub fn check_dynamic_function_call(
         &mut self,
         input: &DynamicOpExpression,
+        interface_location: &Location,
         interface: &Interface,
         expected: &Option<TypeKind>,
     ) -> TypeKind {
@@ -3043,7 +3053,7 @@ impl TypeCheckingVisitor<'_> {
         // Check argument types. Record-typed parameters require `dyn record` at the call site.
         for (expected_input, argument) in func_proto.input.iter().zip(arguments.iter()) {
             let proto_type = expected_input.type_().kind().clone();
-            if interface.is_record_type(&proto_type) {
+            if interface.is_record_type(&proto_type, interface_location) {
                 // Visit without an expected type so only the explicit error below fires.
                 let actual_type = self.visit_expression(argument, &None);
                 if !matches!(actual_type, TypeKind::DynRecord | TypeKind::Err) {
@@ -3058,7 +3068,7 @@ impl TypeCheckingVisitor<'_> {
         }
 
         // Replace interface record types in the output with `dyn record`, then check for futures.
-        let output_type = self.replace_records_with_dyn_record(&func_proto.output_type, interface);
+        let output_type = self.replace_records_with_dyn_record(&func_proto.output_type, interface_location, interface);
         let contains_future = match &output_type {
             TypeKind::Future(..) => true,
             TypeKind::Tuple(tuple) => tuple.elements().iter().any(|t| matches!(t, TypeKind::Future(..))),

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_arg.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_arg.out
@@ -1,0 +1,10 @@
+program foo.aleo;
+
+function main:
+    input r0 as identifier.private;
+    input r1 as dynamic.record;
+    call.dynamic r0 'aleo' 'process' with r1 (as dynamic.record) into r2 (as dynamic.record);
+    output r2 as dynamic.record;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_tuple_return.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_tuple_return.out
@@ -1,0 +1,11 @@
+program foo.aleo;
+
+function main:
+    input r0 as identifier.private;
+    input r1 as dynamic.record;
+    call.dynamic r0 'aleo' 'process' with r1 (as dynamic.record) into r2 r3 (as dynamic.record u64.private);
+    output r2 as dynamic.record;
+    output r3 as u64.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_arg.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_arg.leo
@@ -1,0 +1,19 @@
+// --- library: ops_lib --- //
+
+// --- Next Module: algorithms.leo --- //
+
+export interface Processor {
+    record Token;
+    fn process(token: Token) -> Token;
+}
+
+// --- Next Program --- //
+
+program foo.aleo {
+    fn main(target: identifier, token: dyn record) -> dyn record {
+        return ops_lib::algorithms::Processor@(target)::process(token);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_tuple_return.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_call_module_interface_dyn_record_tuple_return.leo
@@ -1,0 +1,19 @@
+// --- library: ops_lib --- //
+
+// --- Next Module: algorithms.leo --- //
+
+export interface Processor {
+    record Token;
+    fn process(token: Token) -> (Token, u64);
+}
+
+// --- Next Program --- //
+
+program foo.aleo {
+    fn main(target: identifier, token: dyn record) -> (dyn record, u64) {
+        return ops_lib::algorithms::Processor@(target)::process(token);
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
## Motivation

Dynamic calls misclassified records in module-qualified interfaces because record matching inspected the first path segment. Preserve the selected interface location and match the defining program, module path, and record name. The `leo-ast` signature change is intentional: exact identity cannot be recovered from `Interface` alone. Only directly declared record prototypes are handled; inherited record prototypes and inherited dynamic members remain unchanged. The inherited dynamic-member case is tracked separately in #29614.

Fixes #29613.

## Compatibility

`Interface::is_record_type` is a public `leo-ast` API. Requiring the canonical `Location` is therefore a source-breaking change for Rust callers and must be accepted or given a compatibility wrapper as part of the next coordinated `leo-ast` release. Retaining the old location-free classifier would preserve the bug because it cannot distinguish same-named records from different programs or modules. Leo source syntax and the dynamic-call interface are otherwise unchanged.

## Test Plan

- Unit coverage for root, module-qualified, nested-module, wrong-program, sibling-module, undeclared, and non-composite cases.
- Compiler fixtures for module-qualified dynamic-record inputs and tuple outputs.
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- CircleCI: `code-quality`, `leo-executable`, `test-linux`, `test-macos`, `test-windows`.

## Related PRs

#29622 fixes the corresponding qualified-composite lookup in ABI generation independently.