### PR TITLE
Fix cross-library const-generic interface checks

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -358,17 +358,6 @@ jobs:
       - run:
             name: Update Submodules
             command: git submodule update --init --recursive
-      - run:
-          name: Generate library interface expectations
-          command: |
-            UPDATE_EXPECT=1 TEST_FILTER=library_generic_struct_type_sites \
-              cargo test --locked -p leo-compiler --lib test_compiler::test_compiler -- --nocapture
-      - store_artifacts:
-          path: tests/expectations/compiler/interfaces/library_generic_struct_type_sites_valid.out
-          destination: library_generic_struct_type_sites_valid.out
-      - store_artifacts:
-          path: tests/expectations/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.out
-          destination: library_generic_struct_type_sites_mismatch_fail.out
       - build-and-test
       - save_cache:
           key: cargo-v4-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -358,6 +358,17 @@ jobs:
       - run:
             name: Update Submodules
             command: git submodule update --init --recursive
+      - run:
+          name: Generate library interface expectations
+          command: |
+            UPDATE_EXPECT=1 TEST_FILTER=library_generic_struct_type_sites \
+              cargo test --locked -p leo-compiler --lib test_compiler::test_compiler -- --nocapture
+      - store_artifacts:
+          path: tests/expectations/compiler/interfaces/library_generic_struct_type_sites_valid.out
+          destination: library_generic_struct_type_sites_valid.out
+      - store_artifacts:
+          path: tests/expectations/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.out
+          destination: library_generic_struct_type_sites_mismatch_fail.out
       - build-and-test
       - save_cache:
           key: cargo-v4-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}

--- a/crates/passes/src/monomorphization/program.rs
+++ b/crates/passes/src/monomorphization/program.rs
@@ -37,7 +37,13 @@ impl UnitReconstructor for MonomorphizationVisitor<'_> {
                 })
                 .collect(),
             functions: items_at_path(&self.reconstructed_functions, input.name, &[]).collect(),
-            interfaces: input.interfaces,
+            // Reconstruct imported interface prototypes before conformance checking can compare
+            // their const-generic composite types with the consuming program's types.
+            interfaces: input
+                .interfaces
+                .into_iter()
+                .map(|(id, interface)| (id, self.reconstruct_interface(interface)))
+                .collect(),
             stubs: input.stubs,
         }
     }

--- a/tests/expectations/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.out
+++ b/tests/expectations/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.out
@@ -1,0 +1,54 @@
+[ECHI03712004] Error: function `store` does not match the signature required by interface `generic_shapes/Storer`
+Expected:
+fn store(input: Slot::[8u32]) -> Slot::[8u32]
+Found:
+fn store(input: generic_shapes::Slot::[16u32]) -> generic_shapes::Slot::[16u32]
+    ╭─[ compiler-test:12:5 ]
+    │
+ 12 │ ╭─▶     fn store(input: generic_shapes::Slot::[16u32]) -> generic_shapes::Slot::[16u32] {
+    ┆ ┆   
+ 14 │ ├─▶     }
+    │ │           
+    │ ╰─────────── here
+    │     
+    │     Help: Function signatures must match exactly: same parameter types, modes, order, and return type.
+────╯
+[ECHI03712013] Error: field `slot` in record `Token` does not match the type required by interface `generic_shapes/Storer`
+Expected:  Slot::[8u32]
+Found:  generic_shapes::Slot::[16u32]
+   ╭─[ compiler-test:6:9 ]
+   │
+ 6 │         slot: generic_shapes::Slot::[16u32],
+   │
+   ├─[ compiler-test:8:9 ]
+   │
+ 8 │         slot: Slot::[8u32],
+   │         ─────────┬────────  
+   │                  ╰────────── expected by interface here
+   │
+   ├─[ compiler-test:6:9 ]
+   │
+ 6 │         slot: generic_shapes::Slot::[16u32],
+   │         ─────────────────┬─────────────────  
+   │                          ╰─────────────────── type mismatch here
+   │ 
+   │ Help: Field types and modes must match exactly.
+───╯
+[ECHI03712008] Error: mapping `slots` does not match the type required by interface `generic_shapes/Storer`
+Expected: address => Slot::[8u32]
+Found: address => generic_shapes::Slot::[16u32]
+   ╭─[ compiler-test:9:5 ]
+   │
+ 9 │     mapping slots: address => generic_shapes::Slot::[16u32];
+   │ 
+   │ Help: Mapping key and value types must match exactly.
+───╯
+[ECHI03712009] Error: storage variable `current` does not match the type required by interface `generic_shapes/Storer`
+Expected: Slot::[8u32]
+Found: generic_shapes::Slot::[16u32]
+    ╭─[ compiler-test:10:5 ]
+    │
+ 10 │     storage current: generic_shapes::Slot::[16u32];
+    │ 
+    │ Help: Storage variable types must match exactly.
+────╯

--- a/tests/expectations/compiler/interfaces/library_generic_struct_type_sites_valid.out
+++ b/tests/expectations/compiler/interfaces/library_generic_struct_type_sites_valid.out
@@ -1,0 +1,23 @@
+program consumer.aleo;
+
+struct Slot__E5tgmziTR6y:
+    amount as u32;
+
+record Token:
+    owner as address.private;
+    slot as Slot__E5tgmziTR6y.private;
+
+mapping slots:
+    key as address.public;
+    value as Slot__E5tgmziTR6y.public;
+
+mapping current__:
+    key as boolean.public;
+    value as Slot__E5tgmziTR6y.public;
+
+function store:
+    input r0 as Slot__E5tgmziTR6y.private;
+    output r0 as Slot__E5tgmziTR6y.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/tests/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.leo
+++ b/tests/tests/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.leo
@@ -1,0 +1,38 @@
+// Regression: a different specialization is rejected in function, record, mapping,
+// and storage interface types.
+
+// --- library: generic_shapes --- //
+
+export struct Slot::[N: u32] {
+    amount: u32,
+}
+
+export interface Storer {
+    record Token {
+        slot: Slot::[8u32],
+        ..
+    }
+
+    mapping slots: address => Slot::[8u32];
+    storage current: Slot::[8u32];
+
+    fn store(input: Slot::[8u32]) -> Slot::[8u32];
+}
+
+// --- Next Program --- //
+
+program consumer.aleo: generic_shapes::Storer {
+    record Token {
+        slot: generic_shapes::Slot::[16u32],
+    }
+
+    mapping slots: address => generic_shapes::Slot::[16u32];
+    storage current: generic_shapes::Slot::[16u32];
+
+    fn store(input: generic_shapes::Slot::[16u32]) -> generic_shapes::Slot::[16u32] {
+        return input;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.leo
+++ b/tests/tests/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.leo
@@ -1,5 +1,5 @@
-// Regression: a different specialization is rejected in function, record, mapping,
-// and storage interface types.
+// Regression: a different specialization is rejected in function signatures, record
+// fields, mapping values, and storage.
 
 // --- library: generic_shapes --- //
 

--- a/tests/tests/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.leo
+++ b/tests/tests/compiler/interfaces/library_generic_struct_type_sites_mismatch_fail.leo
@@ -9,6 +9,7 @@ export struct Slot::[N: u32] {
 
 export interface Storer {
     record Token {
+        owner: address,
         slot: Slot::[8u32],
         ..
     }
@@ -23,6 +24,7 @@ export interface Storer {
 
 program consumer.aleo: generic_shapes::Storer {
     record Token {
+        owner: address,
         slot: generic_shapes::Slot::[16u32],
     }
 

--- a/tests/tests/compiler/interfaces/library_generic_struct_type_sites_valid.leo
+++ b/tests/tests/compiler/interfaces/library_generic_struct_type_sites_valid.leo
@@ -9,6 +9,7 @@ export struct Slot::[N: u32] {
 
 export interface Storer {
     record Token {
+        owner: address,
         slot: Slot::[8u32],
         ..
     }
@@ -23,6 +24,7 @@ export interface Storer {
 
 program consumer.aleo: generic_shapes::Storer {
     record Token {
+        owner: address,
         slot: generic_shapes::Slot::[8u32],
     }
 

--- a/tests/tests/compiler/interfaces/library_generic_struct_type_sites_valid.leo
+++ b/tests/tests/compiler/interfaces/library_generic_struct_type_sites_valid.leo
@@ -1,0 +1,38 @@
+// Regression: imported interface types are reconstructed before conformance checking.
+// Every type-bearing position uses the same concrete specialization.
+
+// --- library: generic_shapes --- //
+
+export struct Slot::[N: u32] {
+    amount: u32,
+}
+
+export interface Storer {
+    record Token {
+        slot: Slot::[8u32],
+        ..
+    }
+
+    mapping slots: address => Slot::[8u32];
+    storage current: Slot::[8u32];
+
+    fn store(input: Slot::[8u32]) -> Slot::[8u32];
+}
+
+// --- Next Program --- //
+
+program consumer.aleo: generic_shapes::Storer {
+    record Token {
+        slot: generic_shapes::Slot::[8u32],
+    }
+
+    mapping slots: address => generic_shapes::Slot::[8u32];
+    storage current: generic_shapes::Slot::[8u32];
+
+    fn store(input: generic_shapes::Slot::[8u32]) -> generic_shapes::Slot::[8u32] {
+        return input;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/interfaces/library_generic_struct_type_sites_valid.leo
+++ b/tests/tests/compiler/interfaces/library_generic_struct_type_sites_valid.leo
@@ -1,5 +1,6 @@
 // Regression: imported interface types are reconstructed before conformance checking.
-// Every type-bearing position uses the same concrete specialization.
+// Function signatures, record fields, mapping values, and storage use the same
+// concrete specialization.
 
 // --- library: generic_shapes --- //
 


### PR DESCRIPTION
## Motivation

Imported library interfaces skipped type reconstruction, so `Slot[16u32]` could satisfy an interface requiring `Slot[8u32]`. Reconstruct them before conformance checking.

Fixes #29617.

## Test Plan

- Added matching and mismatching library-interface fixtures covering function signatures, record fields, mapping values, and storage.
- `cargo +nightly fmt --all -- --check`
- Fork CI: `cargo nextest run --all --locked --cargo-profile ci --features only_testnet --verbose` on Linux, macOS, and Windows.

## Related PRs

None.
