### PR TITLE
feat(cli): support Aleo bytecode inputs

### DIFF
--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -718,6 +718,30 @@ mod tests {
 
     #[test]
     #[serial]
+    fn aleo_file_path_is_rejected_by_build_test_clean_and_upgrade() {
+        let test_directory = tempfile::tempdir().expect("test directory should be creatable");
+        let aleo_file = test_directory.path().join("standalone.aleo");
+        std::fs::write(&aleo_file, "program standalone.aleo;\n").expect("Aleo fixture should be writable");
+        let aleo_path = aleo_file.to_str().expect("Aleo fixture path should be UTF-8");
+
+        for (command, expected_error) in [
+            ("build", "failed to load Leo project"),
+            ("test", "failed to load Leo project"),
+            ("clean", "doesn't appear to be a Leo package"),
+            ("upgrade", "failed to load Leo project"),
+        ] {
+            let cli = CLI::try_parse_from(["leo", "-q", "--disable-update-check", "--path", aleo_path, command])
+                .unwrap_or_else(|error| panic!("`leo {command}` arguments should parse: {error}"));
+
+            create_session_if_not_set_then(|_| {
+                let error = run_with_args(cli).expect_err("project-only command should reject an Aleo bytecode path");
+                assert!(error.to_string().contains(expected_error), "unexpected `leo {command}` error: {error}");
+            });
+        }
+    }
+
+    #[test]
+    #[serial]
     fn new_inside_workspace_auto_registers() {
         let temp_dir = temp_dir();
         let ws_root = temp_dir.join("ws_new_inside_test");

--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -1161,6 +1161,32 @@ mod tests {
 
     #[test]
     #[serial]
+    fn workspace_deploy_rejects_aleo_imports_directory() {
+        let temp_dir = temp_dir();
+        let ws_root = test_helpers::sample_workspace_with_workspace_deps(&temp_dir, "deploy_imports_directory");
+        let imports = ws_root.join("imports");
+        let deploy = CLI::try_parse_from([
+            "leo",
+            "--disable-update-check",
+            "--path",
+            ws_root.to_str().expect("workspace path should be UTF-8"),
+            "deploy",
+            "--imports-dir",
+            imports.to_str().expect("imports path should be UTF-8"),
+        ])
+        .expect("deploy arguments should parse");
+
+        create_session_if_not_set_then(|_| {
+            let error = run_with_args(deploy).expect_err("workspace deploy should reject an Aleo imports directory");
+            assert!(error.to_string().contains("`--imports-dir` requires `--path` to point to an Aleo bytecode file"));
+        });
+
+        assert!(!ws_root.join("build").exists(), "validation should happen before workspace members are built");
+        let _ = std::fs::remove_dir_all(&ws_root);
+    }
+
+    #[test]
+    #[serial]
     fn workspace_deploy_package_flag_test() {
         // With --package, deploy should only build and deploy that member.
         let temp_dir = temp_dir();

--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -39,7 +39,7 @@ pub struct CLI {
     #[clap(subcommand)]
     command: Commands,
 
-    #[clap(long, global = true, help = "Path to Leo program root folder")]
+    #[clap(long, global = true, help = "Path to a Leo project, or an Aleo bytecode file for run, execute, or deploy")]
     path: Option<PathBuf>,
 
     #[clap(long, global = true, help = "Path to aleo program registry")]
@@ -281,6 +281,14 @@ pub fn run_with_args(cli: CLI) -> Result<()> {
 
         let path = if json_output_arg.is_empty() {
             cli.path
+                .as_deref()
+                .map(|path| {
+                    if path.extension().and_then(|extension| extension.to_str()) == Some("aleo") {
+                        path.parent().unwrap_or(path).to_path_buf()
+                    } else {
+                        path.to_path_buf()
+                    }
+                })
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join("build")
                 .join("json-outputs")
@@ -321,7 +329,7 @@ mod tests {
     use leo_ast::NetworkName;
     use leo_span::create_session_if_not_set_then;
     use serial_test::serial;
-    use std::env::temp_dir;
+    use std::{env::temp_dir, path::PathBuf};
 
     // An unreachable endpoint with no retries stands in for a program that isn't on the network.
     #[test]
@@ -409,6 +417,7 @@ mod tests {
                     inputs: vec!["1u32".to_string(), "2u32".to_string()],
                     env_override,
                     build_options: Default::default(),
+                    imports_dir: None,
                     key_override: Default::default(),
                     with: vec![],
                 },
@@ -459,6 +468,7 @@ mod tests {
                     ],
                     env_override: Default::default(),
                     build_options: Default::default(),
+                    imports_dir: None,
                     key_override: Default::default(),
                     with: vec![],
                 },
@@ -503,6 +513,7 @@ mod tests {
                     name: "inner_1_main".to_string(),
                     inputs: vec!["1u32".to_string(), "2u32".to_string()],
                     build_options: Default::default(),
+                    imports_dir: None,
                     env_override: Default::default(),
                     key_override: Default::default(),
                     with: vec![],
@@ -546,6 +557,7 @@ mod tests {
                     inputs: vec!["1u32".to_string(), "2u32".to_string()],
                     env_override: Default::default(),
                     build_options: Default::default(),
+                    imports_dir: None,
                     key_override: Default::default(),
                     with: vec![],
                 },
@@ -673,6 +685,33 @@ mod tests {
         let cli = CLI::try_parse_from(["leo", "deploy"]).expect("`leo deploy` should parse");
         match cli.command {
             Commands::Deploy { command } => assert_eq!(command.rename, None),
+            _ => panic!("expected a deploy command"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn aleo_imports_directory_flag_parses_for_supported_commands() {
+        let expected = PathBuf::from("imports");
+
+        let cli = CLI::try_parse_from(["leo", "run", "--imports-dir", "imports"])
+            .expect("run should accept an Aleo imports directory");
+        match cli.command {
+            Commands::Run { command } => assert_eq!(command.imports_dir.as_ref(), Some(&expected)),
+            _ => panic!("expected a run command"),
+        }
+
+        let cli = CLI::try_parse_from(["leo", "execute", "--imports-dir", "imports"])
+            .expect("execute should accept an Aleo imports directory");
+        match cli.command {
+            Commands::Execute { command } => assert_eq!(command.imports_dir.as_ref(), Some(&expected)),
+            _ => panic!("expected an execute command"),
+        }
+
+        let cli = CLI::try_parse_from(["leo", "deploy", "--imports-dir", "imports"])
+            .expect("deploy should accept an Aleo imports directory");
+        match cli.command {
+            Commands::Deploy { command } => assert_eq!(command.imports_dir.as_ref(), Some(&expected)),
             _ => panic!("expected a deploy command"),
         }
     }
@@ -1098,6 +1137,7 @@ mod tests {
                     skip: vec![],
                     rename: None,
                     build_options: Default::default(),
+                    imports_dir: None,
                     skip_deploy_certificate: true,
                 },
             },
@@ -1151,6 +1191,7 @@ mod tests {
                     skip: vec![],
                     rename: None,
                     build_options: Default::default(),
+                    imports_dir: None,
                     skip_deploy_certificate: true,
                 },
             },
@@ -1204,6 +1245,7 @@ mod tests {
                     skip: vec![],
                     rename: None,
                     build_options: Default::default(),
+                    imports_dir: None,
                     skip_deploy_certificate: true,
                 },
             },
@@ -1258,6 +1300,7 @@ mod tests {
                     skip: vec![],
                     rename: None,
                     build_options: Default::default(),
+                    imports_dir: None,
                     skip_deploy_certificate: true,
                 },
             },

--- a/crates/leo/src/cli/commands/abi.rs
+++ b/crates/leo/src/cli/commands/abi.rs
@@ -95,16 +95,7 @@ impl Command for LeoAbi {
         let content = std::fs::read_to_string(&self.file).map_err(crate::errors::cli_io_error)?;
         let file_name = self.file.file_name().and_then(|s| s.to_str()).unwrap_or("unknown");
 
-        let imports_dir = self.imports_dir.clone().or_else(|| {
-            let parent = self.file.parent()?;
-            // Per-unit layout: file at `<root>/<unit>/<unit>.aleo` — use `<root>`.
-            if parent.file_name() == self.file.file_stem() {
-                return parent.parent().map(Path::to_path_buf);
-            }
-            // Legacy: sibling `imports/`.
-            let legacy = parent.join("imports");
-            legacy.is_dir().then_some(legacy)
-        });
+        let imports_dir = self.imports_dir.clone().or_else(|| leo_package::default_aleo_imports_directory(&self.file));
 
         // `Process::add_program` is contextual, so dependencies must be loaded in topological order before the main
         // program.
@@ -277,10 +268,7 @@ fn load_and_disassemble_imports<N: Network>(
         if parsed.contains_key(&name) {
             continue;
         }
-        // Try the per-unit layout (`<dir>/<bare>/<name>.aleo`) first, falling back to flat.
-        let bare = name.strip_suffix(".aleo").unwrap_or(&name);
-        let per_unit = imports_dir.join(bare).join(&name);
-        let path = if per_unit.exists() { per_unit } else { imports_dir.join(&name) };
+        let path = leo_package::aleo_import_path(imports_dir, &name);
         let text =
             std::fs::read_to_string(&path).map_err(|e| crate::errors::failed_to_read_import(path.display(), e))?;
         let imported = SvmProgram::<N>::from_str(&text)

--- a/crates/leo/src/cli/commands/deploy.rs
+++ b/crates/leo/src/cli/commands/deploy.rs
@@ -86,6 +86,12 @@ pub struct LeoDeploy {
     pub(crate) rename: Option<String>,
     #[clap(flatten)]
     pub(crate) build_options: BuildOptions,
+    #[clap(
+        long,
+        value_name = "DIR",
+        help = "Directory containing local .aleo imports when --path points to an Aleo bytecode file; other imports are fetched from the network"
+    )]
+    pub(crate) imports_dir: Option<PathBuf>,
     #[clap(long, help = "Use placeholder certificate and verifying keys during deployment.", default_value = "false")]
     pub(crate) skip_deploy_certificate: bool,
 }
@@ -129,6 +135,34 @@ impl Command for LeoDeploy {
     }
 
     fn prelude(&self, context: Context) -> Result<Self::Input> {
+        let path = context.dir()?;
+        if path.extension().and_then(|extension| extension.to_str()) == Some("aleo") {
+            if context.package_filter.is_some() {
+                return Err(crate::errors::custom("`--package` cannot be used with an Aleo bytecode file.").into());
+            }
+            if self.rename.is_some() {
+                return Err(crate::errors::custom("`--rename` is not supported when deploying Aleo bytecode.").into());
+            }
+            let home_path = context.home()?;
+            let network = get_network(&self.env_override.network)?;
+            let endpoint = get_endpoint(&self.env_override.endpoint)?;
+            return Package::from_aleo_file(
+                path,
+                home_path,
+                self.imports_dir.as_deref(),
+                true,
+                self.build_options.no_local,
+                Some(network),
+                Some(&endpoint),
+                self.env_override.network_retries,
+            );
+        }
+        if self.imports_dir.is_some() {
+            return Err(
+                crate::errors::custom("`--imports-dir` requires `--path` to point to an Aleo bytecode file.").into()
+            );
+        }
+
         LeoBuild {
             env_override: self.env_override.clone(),
             options: {
@@ -169,7 +203,12 @@ impl Command for LeoDeploy {
 
     fn execute(self, context: Context) -> Result<Self::Output> {
         // Intercept workspace mode before the default prelude+apply flow.
-        match context.resolve_targets()? {
+        let workspace_targets = if context.dir()?.extension().and_then(|extension| extension.to_str()) == Some("aleo") {
+            None
+        } else {
+            context.resolve_targets()?
+        };
+        match workspace_targets {
             Some((_, targets)) if targets.len() > 1 => handle_workspace_deploy(self, context, targets),
             _ => {
                 // Single target or no workspace: use the standard flow.

--- a/crates/leo/src/cli/commands/deploy.rs
+++ b/crates/leo/src/cli/commands/deploy.rs
@@ -203,11 +203,14 @@ impl Command for LeoDeploy {
 
     fn execute(self, context: Context) -> Result<Self::Output> {
         // Intercept workspace mode before the default prelude+apply flow.
-        let workspace_targets = if context.dir()?.extension().and_then(|extension| extension.to_str()) == Some("aleo") {
-            None
-        } else {
-            context.resolve_targets()?
-        };
+        let path = context.dir()?;
+        let is_aleo_file = path.extension().and_then(|extension| extension.to_str()) == Some("aleo");
+        if self.imports_dir.is_some() && !is_aleo_file {
+            return Err(
+                crate::errors::custom("`--imports-dir` requires `--path` to point to an Aleo bytecode file.").into()
+            );
+        }
+        let workspace_targets = if is_aleo_file { None } else { context.resolve_targets()? };
         match workspace_targets {
             Some((_, targets)) if targets.len() > 1 => handle_workspace_deploy(self, context, targets),
             _ => {

--- a/crates/leo/src/cli/commands/execute.rs
+++ b/crates/leo/src/cli/commands/execute.rs
@@ -87,6 +87,12 @@ pub struct LeoExecute {
     #[clap(flatten)]
     build_options: BuildOptions,
     #[clap(
+        long,
+        value_name = "DIR",
+        help = "Directory containing local .aleo imports when --path points to an Aleo bytecode file; other imports are fetched from the network"
+    )]
+    pub(crate) imports_dir: Option<PathBuf>,
+    #[clap(
         long = "with",
         help = "Additional programs to load into the VM (comma-separated). \
         If a path exists locally, it is read as an .aleo bytecode file; \
@@ -113,6 +119,27 @@ impl Command for LeoExecute {
         let network = get_network(&self.env_override.network)?;
         // Get the endpoint, accounting for overrides.
         let endpoint = get_endpoint(&self.env_override.endpoint)?;
+        if path.extension().and_then(|extension| extension.to_str()) == Some("aleo") {
+            if context.package_filter.is_some() {
+                return Err(crate::errors::custom("`--package` cannot be used with an Aleo bytecode file.").into());
+            }
+            return Package::from_aleo_file(
+                path,
+                home_path,
+                self.imports_dir.as_deref(),
+                true,
+                self.build_options.no_local,
+                Some(network),
+                Some(&endpoint),
+                self.env_override.network_retries,
+            )
+            .map(Some);
+        }
+        if self.imports_dir.is_some() {
+            return Err(
+                crate::errors::custom("`--imports-dir` requires `--path` to point to an Aleo bytecode file.").into()
+            );
+        }
         // If the current directory is a valid Leo package, then build it.
         if Package::from_directory_no_graph(
             path,

--- a/crates/leo/src/cli/commands/run.rs
+++ b/crates/leo/src/cli/commands/run.rs
@@ -23,6 +23,7 @@ use leo_package::{Package, ProgramData};
 use aleo_std::StorageMode;
 
 use clap::Parser;
+use std::path::PathBuf;
 
 #[cfg(not(feature = "only_testnet"))]
 use snarkvm::circuit::{AleoCanaryV0, AleoV0};
@@ -57,6 +58,12 @@ pub struct LeoRun {
     #[clap(flatten)]
     pub(crate) build_options: BuildOptions,
     #[clap(
+        long,
+        value_name = "DIR",
+        help = "Directory containing local .aleo imports when --path points to an Aleo bytecode file; other imports are fetched from the network"
+    )]
+    pub(crate) imports_dir: Option<PathBuf>,
+    #[clap(
         long = "with",
         help = "Additional programs to load into the VM (comma-separated). \
             If a path exists locally, it is read as an .aleo bytecode file; \
@@ -79,6 +86,41 @@ impl Command for LeoRun {
         let path = context.dir()?;
         // Get the path to the home directory.
         let home_path = context.home()?;
+        if path.extension().and_then(|extension| extension.to_str()) == Some("aleo") {
+            if context.package_filter.is_some() {
+                return Err(crate::errors::custom("`--package` cannot be used with an Aleo bytecode file.").into());
+            }
+            let network = match get_network(&self.env_override.network) {
+                Ok(network) => network,
+                Err(_) => {
+                    println!("⚠️ No network specified, defaulting to 'testnet'.");
+                    NetworkName::TestnetV0
+                }
+            };
+            let endpoint = match get_endpoint(&self.env_override.endpoint) {
+                Ok(endpoint) => endpoint,
+                Err(_) => {
+                    println!("⚠️ No endpoint specified, defaulting to '{DEFAULT_ENDPOINT}'.");
+                    DEFAULT_ENDPOINT.to_string()
+                }
+            };
+            return Package::from_aleo_file(
+                path,
+                home_path,
+                self.imports_dir.as_deref(),
+                self.build_options.no_cache,
+                self.build_options.no_local,
+                Some(network),
+                Some(&endpoint),
+                self.env_override.network_retries,
+            )
+            .map(Some);
+        }
+        if self.imports_dir.is_some() {
+            return Err(
+                crate::errors::custom("`--imports-dir` requires `--path` to point to an Aleo bytecode file.").into()
+            );
+        }
         // If the current directory is a valid Leo package, then build it.
         if Package::from_directory_no_graph(
             path,

--- a/crates/leo/src/cli/commands/upgrade.rs
+++ b/crates/leo/src/cli/commands/upgrade.rs
@@ -680,6 +680,7 @@ impl From<&LeoUpgrade> for LeoDeploy {
             skip: upgrade.skip.clone(),
             rename: None,
             build_options: upgrade.build_options.clone(),
+            imports_dir: None,
             skip_deploy_certificate: upgrade.skip_deploy_certificate,
         }
     }

--- a/crates/package/src/package.rs
+++ b/crates/package/src/package.rs
@@ -401,14 +401,24 @@ impl Package {
             edition: None,
             ..Default::default()
         };
-        let mut declared_deps = IndexMap::new();
-        declared_deps.insert(program_symbol, main_dependency.clone());
-        if !no_local && let Some(imports_directory) = imports_directory {
-            let imports_directory = imports_directory
-                .canonicalize()
-                .map_err(|error| crate::errors::failed_path(imports_directory.display(), error))?;
-            collect_local_aleo_imports(&main_program, &imports_directory, &mut declared_deps)?;
-        }
+        let imports_directory = if no_local {
+            None
+        } else {
+            imports_directory
+                .map(|imports_directory| -> Result<PathBuf> {
+                    let imports_directory = imports_directory
+                        .canonicalize()
+                        .map_err(|error| crate::errors::failed_path(imports_directory.display(), error))?;
+                    if !imports_directory.is_dir() {
+                        return Err(
+                            anyhow!("Expected an Aleo imports directory: {}", imports_directory.display()).into()
+                        );
+                    }
+                    Ok(imports_directory)
+                })
+                .transpose()?
+        };
+        let declared_deps = IndexMap::from([(program_symbol, main_dependency.clone())]);
 
         let mut map: IndexMap<Symbol, (Dependency, CompilationUnit)> = IndexMap::new();
         let mut digraph = DiGraph::new(Default::default());
@@ -424,6 +434,7 @@ impl Package {
             &mut digraph,
             no_cache,
             false,
+            imports_directory.as_deref(),
             network_retries,
             &declared_deps,
             &old_lock,
@@ -547,6 +558,7 @@ impl Package {
                     &mut digraph,
                     no_cache,
                     no_local,
+                    None,
                     network_retries,
                     &declared_deps,
                     &old_lock,
@@ -601,12 +613,45 @@ impl Package {
         graph: &mut DiGraph<Symbol>,
         no_cache: bool,
         no_local: bool,
+        aleo_imports_directory: Option<&Path>,
         network_retries: u32,
         declared_deps: &IndexMap<Symbol, Dependency>,
         old_lock: &Lock,
         new_lock: &mut Lock,
         offline: bool,
     ) -> Result<()> {
+        let mut new = new;
+        if new.location == Location::Network
+            && let Some(imports_directory) = aleo_imports_directory
+        {
+            let path = aleo_import_path(imports_directory, &new.name);
+            if path.exists() {
+                if !path.is_file() {
+                    return Err(anyhow!("Expected Aleo import `{}` to be a file: {}", new.name, path.display()).into());
+                }
+                let bytecode = std::fs::read_to_string(&path).map_err(|error| {
+                    crate::errors::util_file_io_error(
+                        format_args!("Trying to read Aleo file at {}", path.display()),
+                        error,
+                    )
+                })?;
+                let imported: SvmProgram<TestnetV0> =
+                    bytecode.parse().map_err(|_| crate::errors::snarkvm_parsing_error(bare_unit_name(&new.name)))?;
+                if imported.id().to_string() != new.name {
+                    return Err(anyhow!(
+                        "Aleo import `{}` resolved to `{}`, but that file declares `{}`.",
+                        new.name,
+                        path.display(),
+                        imported.id()
+                    )
+                    .into());
+                }
+                new.location = Location::Local;
+                new.path = Some(path);
+                new.edition = None;
+            }
+        }
+
         let name_symbol = symbol(&new.name)?;
 
         let unit = match map.entry(name_symbol) {
@@ -725,6 +770,7 @@ impl Package {
                 graph,
                 no_cache,
                 no_local,
+                aleo_imports_directory,
                 network_retries,
                 declared_deps,
                 old_lock,
@@ -753,55 +799,6 @@ pub fn aleo_import_path(imports_directory: &Path, program_name: &str) -> PathBuf
     let bare_name = bare_unit_name(program_name);
     let per_unit_path = imports_directory.join(bare_name).join(program_name);
     if per_unit_path.exists() { per_unit_path } else { imports_directory.join(program_name) }
-}
-
-fn collect_local_aleo_imports(
-    program: &SvmProgram<TestnetV0>,
-    imports_directory: &Path,
-    declared_deps: &mut IndexMap<Symbol, Dependency>,
-) -> Result<()> {
-    let mut worklist = program.imports().keys().copied().collect::<Vec<_>>();
-    while let Some(program_id) = worklist.pop() {
-        let name = program_id.to_string();
-        let name_symbol = symbol(&name)?;
-        if declared_deps.contains_key(&name_symbol) {
-            continue;
-        }
-
-        let path = aleo_import_path(imports_directory, &name);
-        if !path.exists() {
-            continue;
-        }
-        if !path.is_file() {
-            return Err(anyhow!("Expected Aleo import `{name}` to be a file: {}", path.display()).into());
-        }
-
-        let dependency = Dependency {
-            name: name.clone(),
-            location: Location::Local,
-            path: Some(path.clone()),
-            edition: None,
-            ..Default::default()
-        };
-        declared_deps.insert(name_symbol, dependency);
-
-        let bytecode = std::fs::read_to_string(&path).map_err(|error| {
-            crate::errors::util_file_io_error(format_args!("Trying to read Aleo file at {}", path.display()), error)
-        })?;
-        let imported: SvmProgram<TestnetV0> =
-            bytecode.parse().map_err(|_| crate::errors::snarkvm_parsing_error(bare_unit_name(&name)))?;
-        if imported.id() != &program_id {
-            return Err(anyhow!(
-                "Aleo import `{name}` resolved to `{}`, but that file declares `{}`.",
-                path.display(),
-                imported.id()
-            )
-            .into());
-        }
-        worklist.extend(imported.imports().keys().copied());
-    }
-
-    Ok(())
 }
 
 fn main_template(name: &str) -> String {
@@ -1102,17 +1099,68 @@ function main:
             let program_path = root.join("standalone.aleo");
             crate::test_util::write_file(&program_path, MAIN_PROGRAM);
 
-            let main_program: SvmProgram<TestnetV0> = MAIN_PROGRAM.parse().expect("test Aleo program should parse");
-            let mut declared_deps = IndexMap::new();
-            collect_local_aleo_imports(&main_program, &root, &mut declared_deps)
-                .expect("missing local imports should not fail discovery");
             let unit =
-                CompilationUnit::from_aleo_path(Symbol::intern("standalone.aleo"), &program_path, &declared_deps)
+                CompilationUnit::from_aleo_path(Symbol::intern("standalone.aleo"), &program_path, &IndexMap::new())
                     .expect("test Aleo program should load");
 
             let dependency = unit.dependencies.first().expect("test program should have one direct import");
             assert_eq!(dependency.name, "dependency.aleo");
             assert_eq!(dependency.location, Location::Network);
+
+            std::fs::remove_dir_all(root).expect("test directory should be removed");
+        });
+    }
+
+    #[test]
+    fn aleo_file_resolves_local_import_below_network_import() {
+        create_session_if_not_set_then(|_| {
+            let root = crate::test_util::unique_dir("aleo-file-mixed-transitive-imports");
+            let program_path = root.join("standalone.aleo");
+            let imports = root.join("imports");
+            let home = root.join("home");
+            crate::test_util::write_file(&program_path, MAIN_PROGRAM);
+            crate::test_util::write_file(&imports.join("leaf.aleo"), LEAF_PROGRAM);
+            crate::test_util::write_file(
+                &home.join("registry/testnet/dependency/0/dependency.aleo"),
+                DEPENDENCY_PROGRAM,
+            );
+
+            let package = Package::from_aleo_file(
+                &program_path,
+                &home,
+                Some(&imports),
+                false,
+                false,
+                Some(NetworkName::TestnetV0),
+                Some("http://localhost:1"),
+                0,
+            )
+            .expect("a local transitive import below a network import should be used");
+
+            let units =
+                package.compilation_units.iter().map(|unit| (unit.name.to_string(), unit.is_local)).collect::<Vec<_>>();
+            assert_eq!(units, [
+                ("leaf.aleo".to_string(), true),
+                ("dependency.aleo".to_string(), false),
+                ("standalone.aleo".to_string(), true)
+            ]);
+
+            std::fs::remove_dir_all(root).expect("test directory should be removed");
+        });
+    }
+
+    #[test]
+    fn aleo_file_rejects_non_directory_imports_path() {
+        create_session_if_not_set_then(|_| {
+            let root = crate::test_util::unique_dir("aleo-file-invalid-imports-directory");
+            let program_path = root.join("standalone.aleo");
+            let home = root.join("home");
+            crate::test_util::write_file(&program_path, MAIN_PROGRAM);
+            std::fs::create_dir_all(&home).expect("test registry directory should be created");
+
+            let error = Package::from_aleo_file(&program_path, &home, Some(&program_path), false, false, None, None, 0)
+                .expect_err("an imports path that is not a directory should fail");
+            assert!(error.to_string().contains("Expected an Aleo imports directory"));
 
             std::fs::remove_dir_all(root).expect("test directory should be removed");
         });

--- a/crates/package/src/package.rs
+++ b/crates/package/src/package.rs
@@ -21,7 +21,7 @@ use leo_errors::Result;
 use leo_span::Symbol;
 
 use indexmap::{IndexMap, map::Entry};
-use snarkvm::prelude::anyhow;
+use snarkvm::prelude::{Program as SvmProgram, TestnetV0, anyhow};
 use std::path::{Path, PathBuf};
 
 /// Either the bytecode of an Aleo program (if it was a network dependency) or
@@ -257,6 +257,34 @@ impl Package {
         )
     }
 
+    /// Load an Aleo bytecode file as a package, including its local and network imports.
+    ///
+    /// Local imports use the same layouts as `leo abi`: `<root>/<name>/<name>.aleo` for a build bundle, or
+    /// `<imports-directory>/<name>.aleo` for a flat bundle. Imports that are not present there are fetched from the
+    /// network.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_aleo_file<P: AsRef<Path>, Q: AsRef<Path>>(
+        path: P,
+        home_path: Q,
+        imports_directory: Option<&Path>,
+        no_cache: bool,
+        no_local: bool,
+        network: Option<NetworkName>,
+        endpoint: Option<&str>,
+        network_retries: u32,
+    ) -> Result<Self> {
+        Self::from_aleo_file_impl(
+            path.as_ref(),
+            home_path.as_ref(),
+            imports_directory,
+            no_cache,
+            no_local,
+            network,
+            endpoint,
+            network_retries,
+        )
+    }
+
     /// Examine the Leo package at `path` to create a `Package`, including all its dependencies,
     /// obtaining dependencies from the file system or network and topologically sorting them.
     #[allow(clippy::too_many_arguments)]
@@ -330,6 +358,101 @@ impl Package {
                 let path = entry.path();
                 if path.extension().is_some_and(|e| e == extension) { Some(path) } else { None }
             })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn from_aleo_file_impl(
+        path: &Path,
+        home_path: &Path,
+        imports_directory: Option<&Path>,
+        no_cache: bool,
+        no_local: bool,
+        network: Option<NetworkName>,
+        endpoint: Option<&str>,
+        network_retries: u32,
+    ) -> Result<Self> {
+        if path.extension().and_then(|extension| extension.to_str()) != Some("aleo") {
+            return Err(anyhow!("Expected an Aleo bytecode file with the `.aleo` extension: {}", path.display()).into());
+        }
+
+        let path = path.canonicalize().map_err(|error| crate::errors::failed_path(path.display(), error))?;
+        if !path.is_file() {
+            return Err(anyhow!("Expected an Aleo bytecode file: {}", path.display()).into());
+        }
+        let home_path =
+            home_path.canonicalize().map_err(|error| crate::errors::failed_path(home_path.display(), error))?;
+        let bytecode = std::fs::read_to_string(&path).map_err(|error| {
+            crate::errors::util_file_io_error(format_args!("Trying to read Aleo file at {}", path.display()), error)
+        })?;
+        let source_name = path.file_stem().and_then(|name| name.to_str()).unwrap_or("program");
+        let main_program: SvmProgram<TestnetV0> =
+            bytecode.parse().map_err(|_| crate::errors::snarkvm_parsing_error(source_name))?;
+        let program_name = main_program.id().to_string();
+        let program_symbol = symbol(&program_name)?;
+        let base_directory = path
+            .parent()
+            .ok_or_else(|| anyhow!("Aleo bytecode file has no parent directory: {}", path.display()))?
+            .to_path_buf();
+
+        let main_dependency = Dependency {
+            name: program_name.clone(),
+            location: Location::Local,
+            path: Some(path.clone()),
+            edition: None,
+            ..Default::default()
+        };
+        let mut declared_deps = IndexMap::new();
+        declared_deps.insert(program_symbol, main_dependency.clone());
+        if !no_local && let Some(imports_directory) = imports_directory {
+            let imports_directory = imports_directory
+                .canonicalize()
+                .map_err(|error| crate::errors::failed_path(imports_directory.display(), error))?;
+            collect_local_aleo_imports(&main_program, &imports_directory, &mut declared_deps)?;
+        }
+
+        let mut map: IndexMap<Symbol, (Dependency, CompilationUnit)> = IndexMap::new();
+        let mut digraph = DiGraph::new(Default::default());
+        let old_lock = Lock::default();
+        let mut new_lock = Lock::default();
+        Self::graph_build(
+            &home_path,
+            network,
+            endpoint,
+            &main_dependency,
+            main_dependency.clone(),
+            &mut map,
+            &mut digraph,
+            no_cache,
+            false,
+            network_retries,
+            &declared_deps,
+            &old_lock,
+            &mut new_lock,
+            false,
+        )?;
+
+        let compilation_units = digraph
+            .post_order()
+            .map_err(|_| crate::errors::circular_dependency_error())?
+            .into_iter()
+            .map(|name| {
+                map.swap_remove(&name)
+                    .map(|(_, unit)| unit)
+                    .ok_or_else(|| anyhow!("Dependency graph contains an unknown program `{name}`.").into())
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let manifest = Manifest {
+            program: program_name,
+            version: "0.0.0".to_string(),
+            description: String::new(),
+            license: String::new(),
+            leo: env!("CARGO_PKG_VERSION").to_string(),
+            dependencies: None,
+            dev_dependencies: None,
+            no_std: false,
+        };
+
+        Ok(Package { base_directory, workspace_root: None, compilation_units, manifest, dep_graph: digraph })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -614,6 +737,73 @@ impl Package {
     }
 }
 
+/// Return the default directory for local imports of an Aleo bytecode file.
+pub fn default_aleo_imports_directory(path: &Path) -> Option<PathBuf> {
+    let parent = path.parent()?;
+    if parent.file_name() == path.file_stem() {
+        return parent.parent().map(Path::to_path_buf);
+    }
+
+    let imports = parent.join("imports");
+    imports.is_dir().then_some(imports)
+}
+
+/// Return the preferred path for an Aleo import in a flat or per-unit imports directory.
+pub fn aleo_import_path(imports_directory: &Path, program_name: &str) -> PathBuf {
+    let bare_name = bare_unit_name(program_name);
+    let per_unit_path = imports_directory.join(bare_name).join(program_name);
+    if per_unit_path.exists() { per_unit_path } else { imports_directory.join(program_name) }
+}
+
+fn collect_local_aleo_imports(
+    program: &SvmProgram<TestnetV0>,
+    imports_directory: &Path,
+    declared_deps: &mut IndexMap<Symbol, Dependency>,
+) -> Result<()> {
+    let mut worklist = program.imports().keys().copied().collect::<Vec<_>>();
+    while let Some(program_id) = worklist.pop() {
+        let name = program_id.to_string();
+        let name_symbol = symbol(&name)?;
+        if declared_deps.contains_key(&name_symbol) {
+            continue;
+        }
+
+        let path = aleo_import_path(imports_directory, &name);
+        if !path.exists() {
+            continue;
+        }
+        if !path.is_file() {
+            return Err(anyhow!("Expected Aleo import `{name}` to be a file: {}", path.display()).into());
+        }
+
+        let dependency = Dependency {
+            name: name.clone(),
+            location: Location::Local,
+            path: Some(path.clone()),
+            edition: None,
+            ..Default::default()
+        };
+        declared_deps.insert(name_symbol, dependency);
+
+        let bytecode = std::fs::read_to_string(&path).map_err(|error| {
+            crate::errors::util_file_io_error(format_args!("Trying to read Aleo file at {}", path.display()), error)
+        })?;
+        let imported: SvmProgram<TestnetV0> =
+            bytecode.parse().map_err(|_| crate::errors::snarkvm_parsing_error(bare_unit_name(&name)))?;
+        if imported.id() != &program_id {
+            return Err(anyhow!(
+                "Aleo import `{name}` resolved to `{}`, but that file declares `{}`.",
+                path.display(),
+                imported.id()
+            )
+            .into());
+        }
+        worklist.extend(imported.imports().keys().copied());
+    }
+
+    Ok(())
+}
+
 fn main_template(name: &str) -> String {
     format!(
         r#"// The '{name}' program.
@@ -740,6 +930,38 @@ fn collect_declared_deps_recursive(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leo_span::create_session_if_not_set_then;
+
+    const LEAF_PROGRAM: &str = "\
+program leaf.aleo;
+
+function identity:
+    input r0 as u32.private;
+    output r0 as u32.private;
+";
+
+    const DEPENDENCY_PROGRAM: &str = "\
+import leaf.aleo;
+
+program dependency.aleo;
+
+function times_two:
+    input r0 as u32.private;
+    call leaf.aleo/identity r0 into r1;
+    add r1 r1 into r2;
+    output r2 as u32.private;
+";
+
+    const MAIN_PROGRAM: &str = "\
+import dependency.aleo;
+
+program standalone.aleo;
+
+function main:
+    input r0 as u32.private;
+    call dependency.aleo/times_two r0 into r1;
+    output r1 as u32.private;
+";
 
     fn dummy_package(base: &str) -> Package {
         dummy_package_with(base, None)
@@ -825,5 +1047,74 @@ mod tests {
         let pkg = dummy_package_with("/tmp/standalone", None);
         assert_eq!(pkg.build_directory(), PathBuf::from("/tmp/standalone/build"));
         assert_eq!(pkg.unit_build_directory("demo"), PathBuf::from("/tmp/standalone/build/demo"));
+    }
+
+    #[test]
+    fn aleo_file_uses_sibling_imports_directory() {
+        create_session_if_not_set_then(|_| {
+            let root = crate::test_util::unique_dir("aleo-file-flat-imports");
+            let program_path = root.join("standalone.aleo");
+            let home = root.join("home");
+            crate::test_util::write_file(&program_path, MAIN_PROGRAM);
+            crate::test_util::write_file(&root.join("imports/dependency.aleo"), DEPENDENCY_PROGRAM);
+            crate::test_util::write_file(&root.join("imports/leaf.aleo"), LEAF_PROGRAM);
+            std::fs::create_dir_all(&home).expect("test registry directory should be created");
+
+            let package =
+                Package::from_aleo_file(&program_path, &home, Some(&root.join("imports")), false, false, None, None, 0)
+                    .expect("standalone Aleo program should load with its local import");
+
+            let names = package.compilation_units.iter().map(|unit| unit.name.to_string()).collect::<Vec<_>>();
+            assert_eq!(names, ["leaf.aleo", "dependency.aleo", "standalone.aleo"]);
+            assert!(package.compilation_units.iter().all(|unit| unit.is_local));
+            assert_eq!(package.manifest.program, "standalone.aleo");
+
+            std::fs::remove_dir_all(root).expect("test directory should be removed");
+        });
+    }
+
+    #[test]
+    fn aleo_file_uses_per_unit_build_layout() {
+        create_session_if_not_set_then(|_| {
+            let root = crate::test_util::unique_dir("aleo-file-per-unit-imports");
+            let program_path = root.join("standalone/standalone.aleo");
+            let home = root.join("home");
+            crate::test_util::write_file(&program_path, MAIN_PROGRAM);
+            crate::test_util::write_file(&root.join("dependency/dependency.aleo"), DEPENDENCY_PROGRAM);
+            crate::test_util::write_file(&root.join("leaf/leaf.aleo"), LEAF_PROGRAM);
+            std::fs::create_dir_all(&home).expect("test registry directory should be created");
+
+            let package = Package::from_aleo_file(&program_path, &home, Some(&root), false, false, None, None, 0)
+                .expect("standalone Aleo build artifact should load with its local import");
+
+            let names = package.compilation_units.iter().map(|unit| unit.name.to_string()).collect::<Vec<_>>();
+            assert_eq!(names, ["leaf.aleo", "dependency.aleo", "standalone.aleo"]);
+            assert!(package.compilation_units.iter().all(|unit| unit.is_local));
+
+            std::fs::remove_dir_all(root).expect("test directory should be removed");
+        });
+    }
+
+    #[test]
+    fn missing_aleo_import_is_classified_as_network() {
+        create_session_if_not_set_then(|_| {
+            let root = crate::test_util::unique_dir("aleo-file-network-import");
+            let program_path = root.join("standalone.aleo");
+            crate::test_util::write_file(&program_path, MAIN_PROGRAM);
+
+            let main_program: SvmProgram<TestnetV0> = MAIN_PROGRAM.parse().expect("test Aleo program should parse");
+            let mut declared_deps = IndexMap::new();
+            collect_local_aleo_imports(&main_program, &root, &mut declared_deps)
+                .expect("missing local imports should not fail discovery");
+            let unit =
+                CompilationUnit::from_aleo_path(Symbol::intern("standalone.aleo"), &program_path, &declared_deps)
+                    .expect("test Aleo program should load");
+
+            let dependency = unit.dependencies.first().expect("test program should have one direct import");
+            assert_eq!(dependency.name, "dependency.aleo");
+            assert_eq!(dependency.location, Location::Network);
+
+            std::fs::remove_dir_all(root).expect("test directory should be removed");
+        });
     }
 }

--- a/tests/expectations/cli/test_deploy/COMMANDS
+++ b/tests/expectations/cli/test_deploy/COMMANDS
@@ -3,5 +3,8 @@
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
 COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18"
+ALEO_FILE="./build/some_sample_leo_program/some_sample_leo_program.aleo"
 
-$LEO_BIN deploy -y $COMMON_OPTS
+$LEO_BIN build --disable-update-check --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+$LEO_BIN --path $ALEO_FILE deploy -y $COMMON_OPTS
+$LEO_BIN --path $ALEO_FILE execute -y main 1u32 2u32 $COMMON_OPTS

--- a/tests/expectations/cli/test_deploy/STDOUT
+++ b/tests/expectations/cli/test_deploy/STDOUT
@@ -80,3 +80,65 @@ Once it is deployed, it CANNOT be changed.
 Explored XXXXXX blocks.
 Transaction accepted.
 ✅ Deployment confirmed!
+
+📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18
+  To override, pass in `--consensus-heights` or override the environment variable `CONSENSUS_VERSION_HEIGHTS`.
+
+Attempting to determine the consensus version from the latest block height at http://localhost:3030...
+
+🚀 Execution Plan Summary
+──────────────────────────────────────────────
+🔧 Configuration:
+  Private Key:        APrivateKey1zkp8CZNn3yeC...
+  Address:            aleo1rhgdu77hgyqd3xjj8uc...
+  Endpoint:           http://localhost:3030
+  Network:            testnet
+  Consensus Version:  19
+
+🎯 Execution Target:
+  Program:        some_sample_leo_program.aleo
+  Function:       main
+  Source:         local
+
+💸 Fee Info:
+  Priority Fee:   0 μcredits
+  Fee Record:     no (public fee)
+
+⚙️ Actions:
+  - Transaction will NOT be printed to the console.
+  - Transaction will NOT be saved to a file.
+  - Transaction will be broadcast to http://localhost:3030
+──────────────────────────────────────────────
+
+
+➕Adding programs to the VM in the following order:
+  - some_sample_leo_program.aleo (local)
+
+⚙️ Executing some_sample_leo_program.aleo/main...
+
+📊 Execution Cost Summary for some_sample_leo_program.aleo
+──────────────────────────────────────────────
+💰 Cost Breakdown (credits)
+  Transaction Storage:  0.001334
+  On-chain Execution:   0.000000
+  Priority Fee:         0.000000
+  Total Fee:            0.001334
+──────────────────────────────────────────────
+
+➡️  Output
+
+ • 3u32
+
+📡 Broadcasting execution for some_sample_leo_program.aleo...
+💰Your current public balance is XXXXXX credits.
+
+✉️ Broadcasted transaction with:
+  - transaction ID: 'XXXXXX'
+  - fee ID: 'XXXXXX'
+  - fee transaction ID: 'XXXXXX'
+    (use this to check for rejected transactions)
+
+🔄 Searching up to 12 blocks to confirm transaction (this may take several seconds)...
+Explored XXXXXX blocks.
+Transaction accepted.
+✅ Execution confirmed!

--- a/tests/expectations/cli/test_dynamic_call_with_flag/COMMANDS
+++ b/tests/expectations/cli/test_dynamic_call_with_flag/COMMANDS
@@ -14,4 +14,12 @@ ${LEO_BIN} ${COMMON_OPTS} run main ${PROG} ${NET} ${FUNC} ${INPUT} 2>&1 || true
 echo "--- run WITH --with should succeed ---"
 ${LEO_BIN} ${COMMON_OPTS} run main ${PROG} ${NET} ${FUNC} ${INPUT} --with ./extra_prog.aleo
 
+echo "--- run a standalone Aleo file ---"
+${LEO_BIN} ${COMMON_OPTS} --path ./extra_prog.aleo run dbl ${INPUT}
+
+echo "--- write standalone Aleo run JSON output ---"
+${LEO_BIN} ${COMMON_OPTS} --path ./extra_prog.aleo --json-output run dbl ${INPUT}
+cat ./build/json-outputs/run.json
+rm ./build/json-outputs/run.json
+
 exit 0

--- a/tests/expectations/cli/test_dynamic_call_with_flag/STDOUT
+++ b/tests/expectations/cli/test_dynamic_call_with_flag/STDOUT
@@ -31,3 +31,34 @@ Error [ECLI0377045]: Failed to authorize execution: Process authorization failed
 ➡️  Output
 
  • 14u64
+--- run a standalone Aleo file ---
+⚠️ No network specified, defaulting to 'testnet'.
+⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
+⚠️ No network specified, defaulting to 'testnet'.
+⚠️ No valid private key specified, defaulting to 'APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH'.
+
+➕Adding programs to the VM in the following order:
+  - extra_prog.aleo (local)
+
+➡️  Output
+
+ • 14u64
+--- write standalone Aleo run JSON output ---
+⚠️ No network specified, defaulting to 'testnet'.
+⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
+⚠️ No network specified, defaulting to 'testnet'.
+⚠️ No valid private key specified, defaulting to 'APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH'.
+
+➕Adding programs to the VM in the following order:
+  - extra_prog.aleo (local)
+
+➡️  Output
+
+ • 14u64
+{
+  "program": "extra_prog.aleo",
+  "function": "dbl",
+  "outputs": [
+    "14u64"
+  ]
+}

--- a/tests/tests/cli/test_deploy/COMMANDS
+++ b/tests/tests/cli/test_deploy/COMMANDS
@@ -3,5 +3,8 @@
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
 COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18"
+ALEO_FILE="./build/some_sample_leo_program/some_sample_leo_program.aleo"
 
-$LEO_BIN deploy -y $COMMON_OPTS
+$LEO_BIN build --disable-update-check --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+$LEO_BIN --path $ALEO_FILE deploy -y $COMMON_OPTS
+$LEO_BIN --path $ALEO_FILE execute -y main 1u32 2u32 $COMMON_OPTS

--- a/tests/tests/cli/test_dynamic_call_with_flag/COMMANDS
+++ b/tests/tests/cli/test_dynamic_call_with_flag/COMMANDS
@@ -14,4 +14,12 @@ ${LEO_BIN} ${COMMON_OPTS} run main ${PROG} ${NET} ${FUNC} ${INPUT} 2>&1 || true
 echo "--- run WITH --with should succeed ---"
 ${LEO_BIN} ${COMMON_OPTS} run main ${PROG} ${NET} ${FUNC} ${INPUT} --with ./extra_prog.aleo
 
+echo "--- run a standalone Aleo file ---"
+${LEO_BIN} ${COMMON_OPTS} --path ./extra_prog.aleo run dbl ${INPUT}
+
+echo "--- write standalone Aleo run JSON output ---"
+${LEO_BIN} ${COMMON_OPTS} --path ./extra_prog.aleo --json-output run dbl ${INPUT}
+cat ./build/json-outputs/run.json
+rm ./build/json-outputs/run.json
+
 exit 0


### PR DESCRIPTION
## Summary

- Extend the existing global `--path` option so `leo run`, `leo execute`, and `leo deploy` can accept an Aleo bytecode file.
- Treat imports as network dependencies by default. Resolve matching local files only when `--imports-dir` is explicit.
- Reuse the `leo abi` flat and per-program import layouts. Keep dependency order deterministic.
- Write default JSON output beside the input file instead of below the file path.

## Command forms

`--path` is an existing global option that selects a Leo project or workspace. This PR extends it to accept an Aleo bytecode file for `run`, `execute`, and `deploy`. Leo accepts the option before or after the command. The examples put it after the command.

```console
leo run --path <PROGRAM.aleo> [<PROGRAM.aleo>::]<FUNCTION> [INPUTS]... [--imports-dir <DIR>]
leo execute --path <PROGRAM.aleo> [<PROGRAM.aleo>::]<FUNCTION> [INPUTS]... [--imports-dir <DIR>]
leo deploy --path <PROGRAM.aleo> [--imports-dir <DIR>]
```

The function defaults to `main` for `run` and `execute`. All existing command options remain available unless the restrictions below state otherwise.

### Program without imports

```console
leo run --path ./main.aleo main 3u32
leo execute --path ./main.aleo main 3u32 --broadcast --yes
leo deploy --path ./main.aleo --broadcast --yes
```

### Network imports

If `--imports-dir` is absent, Leo resolves all imports with the existing network dependency logic. A nearby `.aleo` file does not make an import local.

```console
leo run --path ./main.aleo main 3u32 --network testnet --endpoint https://api.explorer.provable.com/v1
leo execute --path ./main.aleo main 3u32 --network testnet --endpoint https://api.explorer.provable.com/v1
leo deploy --path ./main.aleo --network testnet --endpoint https://api.explorer.provable.com/v1
```

### Local imports

Pass `--imports-dir` to opt imported programs into local resolution. Leo loads local dependencies before their dependents. For `deploy`, Leo deploys local dependencies before the main program.

```console
leo run --path ./build/main/main.aleo main 3u32 --imports-dir ./build
leo execute --path ./build/main/main.aleo main 3u32 --imports-dir ./build
leo deploy --path ./build/main/main.aleo --imports-dir ./build
```

To make resolution fully local, the directory must contain every transitive import. If an import is missing, Leo resolves that import from the network.

### Mixed local and network imports

With `--imports-dir`, each matching file is local and each missing file is a network dependency. This rule also applies to transitive imports.

```console
leo run --path ./main.aleo main 3u32 --imports-dir ./imports --network testnet
leo execute --path ./main.aleo main 3u32 --imports-dir ./imports --network testnet
leo deploy --path ./main.aleo --imports-dir ./imports --network testnet
```

For `deploy`, local imports are deployment targets. Network imports are not redeployed.

### Ignore local imports

`--no-local` overrides `--imports-dir`. The main `--path` file stays local, but Leo resolves every imported program from the network.

```console
leo run --path ./main.aleo main 3u32 --imports-dir ./imports --no-local
leo execute --path ./main.aleo main 3u32 --imports-dir ./imports --no-local
leo deploy --path ./main.aleo --imports-dir ./imports --no-local
```

### Additional VM programs

`run` and `execute` can combine Aleo bytecode input with the existing `--with` option. An existing path is a local `.aleo` file. Any other value is a program that Leo fetches from the selected network.

```console
leo run --path ./main.aleo main 3u32 --with ./local_helper.aleo,credits.aleo
leo execute --path ./main.aleo main 3u32 --with ./local_helper.aleo,credits.aleo
```

`--with` adds programs to the VM. It does not change the source selection for imports declared by the main program. Use `--imports-dir` for declared local imports.

## Import directory layouts

Leo accepts the same layouts as `leo abi`.

Flat layout:

```text
imports/
├── dependency.aleo
└── transitive.aleo
```

Per-program build layout:

```text
build/
├── dependency/
│   └── dependency.aleo
└── transitive/
    └── transitive.aleo
```

For an import named `dependency.aleo`, Leo first checks `<DIR>/dependency/dependency.aleo`. It then checks `<DIR>/dependency.aleo`. Leo applies the same search recursively to imported local programs.

`--imports-dir` must point to an existing directory. Leo rejects file paths and paths that do not exist.

## Option combinations and restrictions

| Combination | Result |
| --- | --- |
| `.aleo` path without `--imports-dir` | All declared imports use network resolution. |
| `.aleo` path with `--imports-dir` | Matching imports are local. Missing imports use network resolution. |
| `.aleo` path with `--imports-dir --no-local` | Leo ignores the import directory. All declared imports use network resolution. |
| `.aleo` path with `--network`, `--endpoint`, or `--network-retries` | These options control network dependency requests and normal network command behavior. |
| `.aleo` path with `--no-cache` on `run` | Network dependency resolution does not use the dependency cache. |
| Leo project directory with `--imports-dir` | Rejected. `--imports-dir` requires an Aleo bytecode file. |
| `.aleo` path with `--package` | Rejected. A standalone bytecode file has no workspace member selection. |
| `.aleo` path with `deploy --rename` | Rejected. Bytecode program identifiers cannot be renamed safely. |

Project-directory behavior is unchanged when `--path` does not point to an `.aleo` file.

## JSON output

With standalone bytecode input, the default JSON output directory is relative to the input file's parent directory.

```console
leo run --path ./artifacts/main.aleo main 3u32 --json-output
# Writes ./artifacts/build/json-outputs/run.json

leo execute --path ./artifacts/main.aleo main 3u32 --json-output=./result.json
# Writes ./result.json
```

## Dependency model

An Aleo import contains a program ID but no source location. File presence alone cannot identify the intended source. Build directories can contain cached copies of network programs, and automatic local detection could cause `deploy` to redeploy them. Therefore, Leo uses network resolution by default and uses local files only after the user supplies `--imports-dir`.

Closes #29356


