### PR TITLE
feat(cli): support Aleo bytecode upgrades

### DIFF
--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -39,7 +39,11 @@ pub struct CLI {
     #[clap(subcommand)]
     command: Commands,
 
-    #[clap(long, global = true, help = "Path to a Leo project, or an Aleo bytecode file for run, execute, or deploy")]
+    #[clap(
+        long,
+        global = true,
+        help = "Path to a Leo project, or an Aleo bytecode file for run, execute, deploy, or upgrade"
+    )]
     path: Option<PathBuf>,
 
     #[clap(long, global = true, help = "Path to aleo program registry")]
@@ -714,11 +718,18 @@ mod tests {
             Commands::Deploy { command } => assert_eq!(command.imports_dir.as_ref(), Some(&expected)),
             _ => panic!("expected a deploy command"),
         }
+
+        let cli = CLI::try_parse_from(["leo", "upgrade", "--imports-dir", "imports"])
+            .expect("upgrade should accept an Aleo imports directory");
+        match cli.command {
+            Commands::Upgrade { command } => assert_eq!(command.imports_dir.as_ref(), Some(&expected)),
+            _ => panic!("expected an upgrade command"),
+        }
     }
 
     #[test]
     #[serial]
-    fn aleo_file_path_is_rejected_by_build_test_clean_and_upgrade() {
+    fn aleo_file_path_is_rejected_by_build_test_and_clean() {
         let test_directory = tempfile::tempdir().expect("test directory should be creatable");
         let aleo_file = test_directory.path().join("standalone.aleo");
         std::fs::write(&aleo_file, "program standalone.aleo;\n").expect("Aleo fixture should be writable");
@@ -728,7 +739,6 @@ mod tests {
             ("build", "failed to load Leo project"),
             ("test", "failed to load Leo project"),
             ("clean", "doesn't appear to be a Leo package"),
-            ("upgrade", "failed to load Leo project"),
         ] {
             let cli = CLI::try_parse_from(["leo", "-q", "--disable-update-check", "--path", aleo_path, command])
                 .unwrap_or_else(|error| panic!("`leo {command}` arguments should parse: {error}"));
@@ -736,6 +746,33 @@ mod tests {
             create_session_if_not_set_then(|_| {
                 let error = run_with_args(cli).expect_err("project-only command should reject an Aleo bytecode path");
                 assert!(error.to_string().contains(expected_error), "unexpected `leo {command}` error: {error}");
+            });
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn aleo_upgrade_rejects_invalid_path_option_combinations() {
+        let test_directory = tempfile::tempdir().expect("test directory should be creatable");
+        let aleo_file = test_directory.path().join("standalone.aleo");
+        std::fs::write(&aleo_file, "program standalone.aleo;\n").expect("Aleo fixture should be writable");
+        let project_path = test_directory.path().to_str().expect("test directory path should be UTF-8");
+        let aleo_path = aleo_file.to_str().expect("Aleo fixture path should be UTF-8");
+
+        for (arguments, expected_error) in [
+            (
+                ["leo", "-q", "--disable-update-check", "--path", aleo_path, "--package", "member", "upgrade"],
+                "`--package` cannot be used with an Aleo bytecode file",
+            ),
+            (
+                ["leo", "-q", "--disable-update-check", "--path", project_path, "upgrade", "--imports-dir", "imports"],
+                "`--imports-dir` requires `--path` to point to an Aleo bytecode file",
+            ),
+        ] {
+            let cli = CLI::try_parse_from(arguments).expect("upgrade arguments should parse");
+            create_session_if_not_set_then(|_| {
+                let error = run_with_args(cli).expect_err("invalid upgrade option combination should fail");
+                assert!(error.to_string().contains(expected_error), "unexpected upgrade error: {error}");
             });
         }
     }

--- a/crates/leo/src/cli/commands/upgrade.rs
+++ b/crates/leo/src/cli/commands/upgrade.rs
@@ -66,6 +66,12 @@ pub struct LeoUpgrade {
     pub(crate) skip: Vec<String>,
     #[clap(flatten)]
     pub(crate) build_options: BuildOptions,
+    #[clap(
+        long,
+        value_name = "DIR",
+        help = "Directory containing local .aleo imports when --path points to an Aleo bytecode file; other imports are fetched from the network"
+    )]
+    pub(crate) imports_dir: Option<PathBuf>,
     #[clap(long, help = "Skips deployment certificate generation.")]
     pub(crate) skip_deploy_certificate: bool,
 }
@@ -79,6 +85,31 @@ impl Command for LeoUpgrade {
     }
 
     fn prelude(&self, context: Context) -> Result<Self::Input> {
+        let path = context.dir()?;
+        if path.extension().and_then(|extension| extension.to_str()) == Some("aleo") {
+            if context.package_filter.is_some() {
+                return Err(crate::errors::custom("`--package` cannot be used with an Aleo bytecode file.").into());
+            }
+            let home_path = context.home()?;
+            let network = get_network(&self.env_override.network)?;
+            let endpoint = get_endpoint(&self.env_override.endpoint)?;
+            return Package::from_aleo_file(
+                path,
+                home_path,
+                self.imports_dir.as_deref(),
+                true,
+                self.build_options.no_local,
+                Some(network),
+                Some(&endpoint),
+                self.env_override.network_retries,
+            );
+        }
+        if self.imports_dir.is_some() {
+            return Err(
+                crate::errors::custom("`--imports-dir` requires `--path` to point to an Aleo bytecode file.").into()
+            );
+        }
+
         LeoBuild {
             env_override: self.env_override.clone(),
             options: {
@@ -680,7 +711,7 @@ impl From<&LeoUpgrade> for LeoDeploy {
             skip: upgrade.skip.clone(),
             rename: None,
             build_options: upgrade.build_options.clone(),
-            imports_dir: None,
+            imports_dir: upgrade.imports_dir.clone(),
             skip_deploy_certificate: upgrade.skip_deploy_certificate,
         }
     }

--- a/tests/expectations/cli/test_deploy/COMMANDS
+++ b/tests/expectations/cli/test_deploy/COMMANDS
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
 COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18"
@@ -7,4 +9,5 @@ ALEO_FILE="./build/some_sample_leo_program/some_sample_leo_program.aleo"
 
 $LEO_BIN build --disable-update-check --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
 $LEO_BIN --path $ALEO_FILE deploy -y $COMMON_OPTS
+$LEO_BIN --path $ALEO_FILE upgrade --no-local -y $COMMON_OPTS
 $LEO_BIN --path $ALEO_FILE execute -y main 1u32 2u32 $COMMON_OPTS

--- a/tests/expectations/cli/test_deploy/STDOUT
+++ b/tests/expectations/cli/test_deploy/STDOUT
@@ -1,6 +1,6 @@
 
        Leo 🔨 Compiling 'some_sample_leo_program.aleo'
-       Leo     Program size: 0.68 KB / 2000.00 KB
+       Leo     Program size: 0.75 KB / 2000.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'some_sample_leo_program.aleo'.
 
@@ -31,7 +31,7 @@ Attempting to determine the consensus version from the latest block height at ht
 🔧 Your program 'some_sample_leo_program.aleo' has the following constructor.
 ──────────────────────────────────────────────
 constructor:
-    assert.eq edition 0u16;
+    assert.eq program_owner aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
 ──────────────────────────────────────────────
 Once it is deployed, it CANNOT be changed.
 
@@ -40,19 +40,19 @@ Once it is deployed, it CANNOT be changed.
 
 📊 Deployment Summary for some_sample_leo_program.aleo
 ──────────────────────────────────────────────
-  Program Size:         0.68 KB / 2000.00 KB
+  Program Size:         0.75 KB / 2000.00 KB
   Total Variables:      99,771
   Total Constraints:    76,101
   Max Variables:        XXXXXX
   Max Constraints:      XXXXXX
 
 💰 Cost Breakdown (credits)
-  Transaction Storage:  3.270000
+  Transaction Storage:  3.300000
   Program Synthesis:    0.540371
   Namespace:            1.000000
   Constructor:          0.002000
   Priority Fee:         0.000000
-  Total Fee:            4.812371
+  Total Fee:            4.842371
   Function 'main'
     Total Execution Cost:   0.001334
     |- Storage Cost:        0.001334
@@ -80,6 +80,78 @@ Once it is deployed, it CANNOT be changed.
 Explored XXXXXX blocks.
 Transaction accepted.
 ✅ Deployment confirmed!
+
+📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18
+  To override, pass in `--consensus-heights` or override the environment variable `CONSENSUS_VERSION_HEIGHTS`.
+
+Attempting to determine the consensus version from the latest block height at http://localhost:3030...
+
+🛠️  Deployment Plan Summary
+──────────────────────────────────────────────
+🔧 Configuration:
+  Private Key:        APrivateKey1zkp8CZNn3yeC...
+  Address:            aleo1rhgdu77hgyqd3xjj8uc...
+  Endpoint:           http://localhost:3030
+  Network:            testnet
+  Consensus Version:  19
+
+📦 Deployment Tasks:
+  • some_sample_leo_program.aleo  │ priority fee: 0  │ fee record: no (public fee)
+
+⚙️ Actions:
+  • Transaction(s) will NOT be printed to the console.
+  • Transaction(s) will NOT be saved to a file.
+  • Transaction(s) will be broadcast to http://localhost:3030
+──────────────────────────────────────────────
+
+Loaded the following programs into the VM:
+ - credits.aleo (default)
+ - some_sample_leo_program.aleo (edition 0)
+
+📦 Creating deployment transaction for 'some_sample_leo_program.aleo'...
+
+
+📊 Deployment Summary for some_sample_leo_program.aleo
+──────────────────────────────────────────────
+  Program Size:         0.75 KB / 2000.00 KB
+  Total Variables:      99,771
+  Total Constraints:    76,101
+  Max Variables:        XXXXXX
+  Max Constraints:      XXXXXX
+
+💰 Cost Breakdown (credits)
+  Transaction Storage:  3.300000
+  Program Synthesis:    0.540371
+  Namespace:            1.000000
+  Constructor:          0.002000
+  Priority Fee:         0.000000
+  Total Fee:            4.842371
+  Function 'main'
+    Total Execution Cost:   0.001334
+    |- Storage Cost:        0.001334
+    |- Finalize Cost:       0.000000
+  Function 'mint'
+    Total Execution Cost:   0.001536
+    |- Storage Cost:        0.001536
+    |- Finalize Cost:       0.000000
+  Function 'dynamic_transfer'
+    Total Execution Cost:   0.000000 (lower bound)
+    |- Storage Cost:        N/A (dynamic call)
+    |- Finalize Cost:       0.000000 (lower bound)
+──────────────────────────────────────────────
+📡 Broadcasting upgrade for some_sample_leo_program.aleo...
+💰Your current public balance is XXXXXX credits.
+
+✉️ Broadcasted transaction with:
+  - transaction ID: 'XXXXXX'
+  - fee ID: 'XXXXXX'
+  - fee transaction ID: 'XXXXXX'
+    (use this to check for rejected transactions)
+
+🔄 Searching up to 12 blocks to confirm transaction (this may take several seconds)...
+Explored XXXXXX blocks.
+Transaction accepted.
+✅ Upgrade confirmed!
 
 📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18
   To override, pass in `--consensus-heights` or override the environment variable `CONSENSUS_VERSION_HEIGHTS`.

--- a/tests/expectations/cli/test_deploy/contents/build/some_sample_leo_program/some_sample_leo_program.aleo
+++ b/tests/expectations/cli/test_deploy/contents/build/some_sample_leo_program/some_sample_leo_program.aleo
@@ -24,4 +24,4 @@ function dynamic_transfer:
     output r3 as dynamic.record;
 
 constructor:
-    assert.eq edition 0u16;
+    assert.eq program_owner aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;

--- a/tests/expectations/cli/test_deploy/contents/src/main.leo
+++ b/tests/expectations/cli/test_deploy/contents/src/main.leo
@@ -18,6 +18,6 @@ program some_sample_leo_program.aleo {
         return _dynamic_call::[dyn record, address, dyn record](target, 'aleo', 'transfer', token, to);
     }
 
-    @noupgrade
+    @admin(address="aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px")
     constructor() {}
 }

--- a/tests/tests/cli/test_deploy/COMMANDS
+++ b/tests/tests/cli/test_deploy/COMMANDS
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
 COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030} --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18"
@@ -7,4 +9,5 @@ ALEO_FILE="./build/some_sample_leo_program/some_sample_leo_program.aleo"
 
 $LEO_BIN build --disable-update-check --network testnet --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
 $LEO_BIN --path $ALEO_FILE deploy -y $COMMON_OPTS
+$LEO_BIN --path $ALEO_FILE upgrade --no-local -y $COMMON_OPTS
 $LEO_BIN --path $ALEO_FILE execute -y main 1u32 2u32 $COMMON_OPTS

--- a/tests/tests/cli/test_deploy/contents/src/main.leo
+++ b/tests/tests/cli/test_deploy/contents/src/main.leo
@@ -18,6 +18,6 @@ program some_sample_leo_program.aleo {
         return _dynamic_call::[dyn record, address, dyn record](target, 'aleo', 'transfer', token, to);
     }
 
-    @noupgrade
+    @admin(address="aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px")
     constructor() {}
 }


### PR DESCRIPTION
## Summary

- Let `leo upgrade` accept a standalone Aleo bytecode file through `--path`.
- Add `--imports-dir` support and load other imports from the selected network.
- Support `--no-local` for network-only dependency resolution.
- Reject package filters and invalid import-directory use for standalone bytecode upgrades.
- Extend the CLI deployment fixture to deploy, upgrade, and execute compiled Aleo bytecode.